### PR TITLE
Support for Swift 1.2

### DIFF
--- a/OAuthSwift/HMAC.swift
+++ b/OAuthSwift/HMAC.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public class HMAC {
     
-    let key:[Byte] = []
+    let key:[UInt8] = []
     
     class internal func sha1(# key: NSData, message: NSData) -> NSData? {
         var key = key.bytes()
@@ -23,15 +23,15 @@ public class HMAC {
         }
         
         if (key.count < 64) {
-            key = key + [Byte](count: 64 - key.count, repeatedValue: 0)
+            key = key + [UInt8](count: 64 - key.count, repeatedValue: 0)
         }
         
         //
-        var opad = [Byte](count: 64, repeatedValue: 0x5c)
+        var opad = [UInt8](count: 64, repeatedValue: 0x5c)
         for (idx, val) in enumerate(key) {
             opad[idx] = key[idx] ^ opad[idx]
         }
-        var ipad = [Byte](count: 64, repeatedValue: 0x36)
+        var ipad = [UInt8](count: 64, repeatedValue: 0x36)
         for (idx, val) in enumerate(key) {
             ipad[idx] = key[idx] ^ ipad[idx]
         }

--- a/OAuthSwift/Int+OAuthSwift.swift
+++ b/OAuthSwift/Int+OAuthSwift.swift
@@ -9,20 +9,20 @@
 import Foundation
 
 extension Int {
-    public func bytes(_ totalBytes: Int = sizeof(Int)) -> [Byte] {
+    public func bytes(_ totalBytes: Int = sizeof(Int)) -> [UInt8] {
         return arrayOfBytes(self, length: totalBytes)
     }
 }
 
-func arrayOfBytes<T>(value:T, length:Int? = nil) -> [Byte] {
+func arrayOfBytes<T>(value:T, length:Int? = nil) -> [UInt8] {
     let totalBytes = length ?? (sizeofValue(value) * 8)
     var v = value
     
     var valuePointer = UnsafeMutablePointer<T>.alloc(1)
     valuePointer.memory = value
     
-    var bytesPointer = UnsafeMutablePointer<Byte>(valuePointer)
-    var bytes = [Byte](count: totalBytes, repeatedValue: 0)
+    var bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
+    var bytes = [UInt8](count: totalBytes, repeatedValue: 0)
     for j in 0..<min(sizeof(T),totalBytes) {
         bytes[totalBytes - 1 - j] = (bytesPointer + j).memory
     }

--- a/OAuthSwift/NSData+OAuthSwift.swift
+++ b/OAuthSwift/NSData+OAuthSwift.swift
@@ -9,21 +9,21 @@
 import Foundation
 
 extension NSMutableData {
-    internal func appendBytes(arrayOfBytes: [Byte]) {
+    internal func appendBytes(var arrayOfBytes: [UInt8]) {
         self.appendBytes(arrayOfBytes, length: arrayOfBytes.count)
     }
     
 }
 
 extension NSData {
-    func bytes() -> [Byte] {
-        let count = self.length / sizeof(Byte)
-        var bytesArray = [Byte](count: count, repeatedValue: 0)
-        self.getBytes(&bytesArray, length:count * sizeof(Byte))
+    func bytes() -> [UInt8] {
+        let count = self.length / sizeof(UInt8)
+        var bytesArray = [UInt8](count: count, repeatedValue: 0)
+        self.getBytes(&bytesArray, length:count * sizeof(UInt8))
         return bytesArray
     }
     
-    class public func withBytes(bytes: [Byte]) -> NSData {
+    class public func withBytes(bytes: [UInt8]) -> NSData {
         return NSData(bytes: bytes, length: bytes.count)
     }
 }

--- a/OAuthSwift/NSURL+OAuthSwift.swift
+++ b/OAuthSwift/NSURL+OAuthSwift.swift
@@ -12,14 +12,14 @@ import Foundation
 extension NSURL {
 
     func URLByAppendingQueryString(queryString: String) -> NSURL {
-        if queryString.utf16Count == 0 {
+        if count(queryString.utf16) == 0 {
             return self
         }
 
         var absoluteURLString = self.absoluteString!
 
         if absoluteURLString.hasSuffix("?") {
-            absoluteURLString = (absoluteURLString as NSString).substringToIndex(absoluteURLString.utf16Count - 1)
+            absoluteURLString = (absoluteURLString as NSString).substringToIndex(count(absoluteURLString.utf16) - 1)
         }
 
         let URLString = absoluteURLString + (absoluteURLString.rangeOfString("?") != nil ? "&" : "?") + queryString

--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -57,7 +57,7 @@ public class OAuth1Swift: NSObject {
                 notification in
                 //NSNotificationCenter.defaultCenter().removeObserver(self)
                 NSNotificationCenter.defaultCenter().removeObserver(self.observer!)
-                let url = notification.userInfo![CallbackNotification.optionsURLKey] as NSURL
+                let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
                 let parameters = url.query!.parametersFromQueryString()
                 if (parameters["oauth_token"] != nil && parameters["oauth_verifier"] != nil) {
                     var credential: OAuthSwiftCredential = self.client.credential
@@ -93,7 +93,7 @@ public class OAuth1Swift: NSObject {
         }
         self.client.post(self.request_token_url, parameters: parameters, success: {
             data, response in
-            let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String
+            let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
             let parameters = responseString.parametersFromQueryString()
             self.client.credential.oauth_token = parameters["oauth_token"]!
             self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!
@@ -108,7 +108,7 @@ public class OAuth1Swift: NSObject {
         parameters["oauth_verifier"] = self.client.credential.oauth_verifier
         self.client.post(self.access_token_url, parameters: parameters, success: {
             data, response in
-            let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String
+            let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
             let parameters = responseString.parametersFromQueryString()
             self.client.credential.oauth_token = parameters["oauth_token"]!
             self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -54,7 +54,7 @@ public class OAuth2Swift: NSObject {
         self.observer = NSNotificationCenter.defaultCenter().addObserverForName(CallbackNotification.notificationName, object: nil, queue: NSOperationQueue.mainQueue(), usingBlock:{
             notification in
             NSNotificationCenter.defaultCenter().removeObserver(self.observer!)
-            let url = notification.userInfo![CallbackNotification.optionsURLKey] as NSURL
+            let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
             var parameters: Dictionary<String, String> = Dictionary()
             if ((url.query) != nil){
                 parameters = url.query!.parametersFromQueryString()
@@ -115,9 +115,9 @@ public class OAuth2Swift: NSObject {
             var responseJSON: AnyObject? = NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.MutableContainers, error: nil)
             var accessToken = ""
             if let parameters:NSDictionary = responseJSON as? NSDictionary{
-                accessToken = parameters["access_token"] as String
+                accessToken = parameters["access_token"] as! String
             } else {
-                let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String
+                let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
                 let parameters = responseString.parametersFromQueryString()
                 accessToken = parameters["access_token"]!
             }

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -20,11 +20,11 @@ public class OAuthSwiftClient {
     
     var credential: OAuthSwiftCredential
     
-    init(consumerKey: String, consumerSecret: String) {
+    public init(consumerKey: String, consumerSecret: String) {
         self.credential = OAuthSwiftCredential(consumer_key: consumerKey, consumer_secret: consumerSecret)
     }
     
-    init(consumerKey: String, consumerSecret: String, accessToken: String, accessTokenSecret: String) {
+    public init(consumerKey: String, consumerSecret: String, accessToken: String, accessTokenSecret: String) {
         self.credential = OAuthSwiftCredential(oauth_token: accessToken, oauth_token_secret: accessTokenSecret)
         self.credential.consumer_key = consumerKey
         self.credential.consumer_secret = consumerSecret
@@ -32,23 +32,23 @@ public class OAuthSwiftClient {
     }
     
     public func get(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "GET", parameters: parameters, success, failure)
+        self.request(urlString, method: "GET", parameters: parameters, success: success, failure: failure)
     }
     
     public func post(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "POST", parameters: parameters, success, failure)
+        self.request(urlString, method: "POST", parameters: parameters, success: success, failure: failure)
     }
 
     public func put(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "PUT", parameters: parameters, success, failure)
+        self.request(urlString, method: "PUT", parameters: parameters, success: success, failure: failure)
     }
 
     public func delete(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "DELETE", parameters: parameters, success, failure)
+        self.request(urlString, method: "DELETE", parameters: parameters, success: success, failure: failure)
     }
 
     public func patch(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "PATCH", parameters: parameters, success, failure)
+        self.request(urlString, method: "PATCH", parameters: parameters, success: success, failure: failure)
     }
 
     func request(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
@@ -66,7 +66,7 @@ public class OAuthSwiftClient {
 
     }
 
-    class func authorizationHeaderForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
+    public class func authorizationHeaderForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
         var authorizationParameters = Dictionary<String, AnyObject>()
         authorizationParameters["oauth_version"] = OAuth.version
         authorizationParameters["oauth_signature_method"] =  OAuth.signatureMethod
@@ -104,7 +104,7 @@ public class OAuthSwiftClient {
         return "OAuth " + ", ".join(headerComponents)
     }
     
-    class func signatureForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
+    public class func signatureForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
         var tokenSecret: NSString = ""
         tokenSecret = credential.oauth_token_secret.urlEncodedStringWithEncoding(dataEncoding)
         

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -17,11 +17,11 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     override init(){
         
     }
-    init(consumer_key: String, consumer_secret: String){
+    public init(consumer_key: String, consumer_secret: String){
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
     }
-    init(oauth_token: String, oauth_token_secret: String){
+    public init(oauth_token: String, oauth_token_secret: String){
         self.oauth_token = oauth_token
         self.oauth_token_secret = oauth_token_secret
     }
@@ -39,11 +39,11 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     // extension OAuthSwiftCredential: NSCoding {
     public required convenience init(coder decoder: NSCoder) {
         self.init()
-        self.consumer_key = decoder.decodeObjectForKey(CodingKeys.consumerKey) as? String ?? String()
-        self.consumer_secret = decoder.decodeObjectForKey(CodingKeys.consumerSecret) as? String ?? String()
-        self.oauth_token = decoder.decodeObjectForKey(CodingKeys.oauthToken) as? String ?? String()
-        self.oauth_token_secret = decoder.decodeObjectForKey(CodingKeys.oauthTokenSecret) as? String ?? String()
-        self.oauth_verifier = decoder.decodeObjectForKey(CodingKeys.oauthVerifier) as? String ?? String()
+        self.consumer_key = (decoder.decodeObjectForKey(CodingKeys.consumerKey) as? String) ?? String()
+        self.consumer_secret = (decoder.decodeObjectForKey(CodingKeys.consumerSecret) as? String) ?? String()
+        self.oauth_token = (decoder.decodeObjectForKey(CodingKeys.oauthToken) as? String) ?? String()
+        self.oauth_token_secret = (decoder.decodeObjectForKey(CodingKeys.oauthTokenSecret) as? String) ?? String()
+        self.oauth_verifier = (decoder.decodeObjectForKey(CodingKeys.oauthVerifier) as? String) ?? String()
     }
     
     public func encodeWithCoder(coder: NSCoder) {

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -55,7 +55,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
     
     init(request: NSURLRequest) {
         self.request = request as? NSMutableURLRequest
-        self.URL = request.URL
+        self.URL = request.URL!
         self.HTTPMethod = request.HTTPMethod!
         self.headers = [:]
         self.parameters = [:]
@@ -118,20 +118,21 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         }
     }
     
-    func connection(connection: NSURLConnection!, didReceiveResponse response: NSURLResponse!) {
+
+    public func connection(connection: NSURLConnection, didReceiveResponse response: NSURLResponse) {
         self.response = response as? NSHTTPURLResponse
         
         self.responseData.length = 0
     }
     
-    func connection(connection: NSURLConnection!, didSendBodyData bytesWritten: Int, totalBytesWritten: Int, totalBytesExpectedToWrite: Int) {
+    public func connection(connection: NSURLConnection, didSendBodyData bytesWritten: Int, totalBytesWritten: Int, totalBytesExpectedToWrite: Int) {
     }
     
-    func connection(connection: NSURLConnection!, didReceiveData data: NSData!) {
+    public func connection(connection: NSURLConnection, didReceiveData data: NSData) {
         self.responseData.appendData(data)
     }
     
-    func connection(connection: NSURLConnection!, didFailWithError error: NSError!) {
+    public func connection(connection: NSURLConnection, didFailWithError error: NSError) {
         #if os(iOS)
             UIApplication.sharedApplication().networkActivityIndicatorVisible = false
         #endif
@@ -139,15 +140,15 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         self.failureHandler?(error: error)
     }
     
-    func connectionDidFinishLoading(connection: NSURLConnection!) {
+    public func connectionDidFinishLoading(connection: NSURLConnection) {
         #if os(iOS)
             UIApplication.sharedApplication().networkActivityIndicatorVisible = false
         #endif
         
         if self.response.statusCode >= 400 {
             let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
-            let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString!)
-            let userInfo = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
+            let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as! String)
+            let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
             let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
             self.failureHandler?(error: error)
             return
@@ -168,7 +169,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
         }
         
-        return NSString(data: data, encoding: encoding)!
+        return NSString(data: data, encoding: encoding)! as! String
     }
     
     class func descriptionForHTTPStatus(status: Int, responseString: String) -> String {

--- a/OAuthSwift/SHA1.swift
+++ b/OAuthSwift/SHA1.swift
@@ -129,6 +129,6 @@ class SHA1 {
             buf.appendBytes(&i, length: sizeofValue(i))
         })
         
-        return buf.copy() as NSData;
+        return buf.copy() as! NSData;
     }
 }

--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -37,9 +37,9 @@ extension String {
 
         var raw: NSString = self
         
-        let result = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, raw, charactersToLeaveUnescaped, charactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding)) as NSString
+        let result = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, raw, charactersToLeaveUnescaped, charactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding))
 
-        return result
+        return result as String
     }
 
     func parametersFromQueryString() -> Dictionary<String, String> {
@@ -60,7 +60,7 @@ extension String {
             scanner.scanString("&", intoString: nil)
 
             if (key != nil && value != nil) {
-                parameters.updateValue(value!, forKey: key!)
+                parameters.updateValue(value! as String, forKey: key! as String)
             }
         }
         
@@ -107,11 +107,11 @@ extension String {
     }
     //统计长度
     func length()->Int{
-        return countElements(self)
+        return count(self)
     }
     //统计长度(别名)
     func size()->Int{
-        return countElements(self)
+        return count(self)
     }
     //重复字符串
     func repeat(times: Int) -> String{

--- a/OAuthSwiftDemo/AppDelegate.swift
+++ b/OAuthSwiftDemo/AppDelegate.swift
@@ -14,8 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWebViewDelegate {
     
     var window: UIWindow?
     
-    
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         
@@ -49,7 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWebViewDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
     
-    func application(application: UIApplication!, openURL url: NSURL!, sourceApplication: String!, annotation: AnyObject!) -> Bool {
+    func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
         println(url)
         if (url.host == "oauth-callback") {
             if (url.path!.hasPrefix("/twitter") || url.path!.hasPrefix("/flickr") || url.path!.hasPrefix("/fitbit")

--- a/OAuthSwiftDemo/WebViewController.swift
+++ b/OAuthSwiftDemo/WebViewController.swift
@@ -31,9 +31,9 @@ class WebViewController: OAuthWebViewController, UIWebViewDelegate {
         let req = NSURLRequest(URL: targetURL)
         webView.loadRequest(req)
     }
-    func webView(webView: UIWebView!, shouldStartLoadWithRequest request: NSURLRequest!, navigationType: UIWebViewNavigationType) -> Bool {
-        println(request.URL.scheme)
-        if (request.URL.scheme == "oauth-swift"){
+    func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        println(request.URL)
+        if (request.URL!.scheme == "oauth-swift"){
             self.dismissViewControllerAnimated(true, completion: nil)
         }
         return true


### PR DESCRIPTION
- Changed Byte type to UInt8
- Changed visibility of methods in OAuthSwiftClient to public to support inheriting/overiding
  when the library is used with "use_frameworks!" in Cocoa Pods