### PR TITLE
Oauthswift salesforce

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -68,7 +68,7 @@ public class OAuth2Swift: NSObject {
                 success(credential: self.client.credential, response: nil)
             }
             if (parameters["code"] != nil){
-                self.postOAuthAccessTokenWithRequestTokenByCode(parameters["code"]!,
+                self.postOAuthAccessTokenWithRequestTokenByCode(parameters["code"]!.stringByRemovingPercentEncoding!,
                     callbackURL:callbackURL,
                     success: { credential, response in
                         success(credential: credential, response: response)

--- a/OAuthSwiftDemo/AppDelegate.swift
+++ b/OAuthSwiftDemo/AppDelegate.swift
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWebViewDelegate {
              || url.path!.hasPrefix("/withings") || url.path!.hasPrefix("/linkedin")) {
                 OAuth1Swift.handleOpenURL(url)
             }
-            if ( url.path!.hasPrefix("/github" ) || url.path!.hasPrefix("/instagram" ) || url.path!.hasPrefix("/foursquare") || url.path!.hasPrefix("/dropbox") || url.path!.hasPrefix("/dribbble") ) {
+            if ( url.path!.hasPrefix("/github" ) || url.path!.hasPrefix("/instagram" ) || url.path!.hasPrefix("/foursquare") || url.path!.hasPrefix("/dropbox") || url.path!.hasPrefix("/dribbble") || url.path!.hasPrefix("/salesforce") ) {
                 OAuth2Swift.handleOpenURL(url)
             }
         }

--- a/OAuthSwiftDemo/Constants.swift
+++ b/OAuthSwiftDemo/Constants.swift
@@ -15,8 +15,8 @@ let Twitter =
 ]
 let Salesforce =
 [
-    "consumerKey": "3MVG9fMtCkV6eLhdjZ8TO0bd8hB1S7vtYzaYRkr8PDg92amDvVDSHzbYLaHinwTyYx25jZmdVgPpZ7f18Hyo2",
-    "consumerSecret": "2395602594367212505"
+    "consumerKey": "***",
+    "consumerSecret": "***"
 ]
 let Flickr =
 [

--- a/OAuthSwiftDemo/Constants.swift
+++ b/OAuthSwiftDemo/Constants.swift
@@ -13,6 +13,11 @@ let Twitter =
     "consumerKey": "***",
     "consumerSecret": "***"
 ]
+let Salesforce =
+[
+    "consumerKey": "3MVG9fMtCkV6eLhdjZ8TO0bd8hB1S7vtYzaYRkr8PDg92amDvVDSHzbYLaHinwTyYx25jZmdVgPpZ7f18Hyo2",
+    "consumerSecret": "2395602594367212505"
+]
 let Flickr =
 [
     "consumerKey": "***",

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -11,7 +11,7 @@ import OAuthSwift
 
 class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Dropbox", "Dribbble"]
+    var services = ["Twitter", "Salesforce", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Dropbox", "Dribbble"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -105,6 +105,23 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
             })
+        
+    }
+    
+    func doOAuthSalesforce(){
+        let oauthswift = OAuth2Swift(
+            consumerKey:    Salesforce["consumerKey"]!,
+            consumerSecret: Salesforce["consumerSecret"]!,
+            authorizeUrl:   "https://login.salesforce.com/services/oauth2/authorize",
+            accessTokenUrl: "https://login.salesforce.com/services/oauth2/token",
+            responseType:   "code"
+        )
+        oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/salesforce")!, scope: "full", state: "SALESFORCE", success: {
+            credential, response in
+            self.showAlertView("Salesforce", message: "oauth_token:\(credential.oauth_token)")
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
+        })
         
     }
 
@@ -281,6 +298,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         switch service {
             case "Twitter":
                 doOAuthTwitter()
+            case "Salesforce":
+                doOAuthSalesforce()
             case "Flickr":
                 doOAuthFlickr()
             case "Github":


### PR DESCRIPTION
I added support for Salesforce authentication. It is all pretty straight forward except I added a call to remove encoding on code response keys. Salesforce definitely sends keys that have special characters which require URLEncoding (and were breaking my app until I removed them). I suspect other providers may have similar issues