### PR TITLE
Allow optional skipping the oauth verifier

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -18,6 +18,8 @@ public class OAuth1Swift: NSObject {
 
     public var webViewController: OAuthWebViewController?
 
+    public var allowMissingOauthVerifier: Bool = false
+
     var consumer_key: String
     var consumer_secret: String
     var request_token_url: String
@@ -59,10 +61,12 @@ public class OAuth1Swift: NSObject {
                 NSNotificationCenter.defaultCenter().removeObserver(self.observer!)
                 let url = notification.userInfo![CallbackNotification.optionsURLKey] as NSURL
                 let parameters = url.query!.parametersFromQueryString()
-                if (parameters["oauth_token"] != nil && parameters["oauth_verifier"] != nil) {
+                if (parameters["oauth_token"] != nil && (self.allowMissingOauthVerifier || parameters["oauth_verifier"] != nil)) {
                     var credential: OAuthSwiftCredential = self.client.credential
                     self.client.credential.oauth_token = parameters["oauth_token"]!
-                    self.client.credential.oauth_verifier = parameters["oauth_verifier"]!
+                    if (parameters["oauth_verifier"] != nil) {
+                        self.client.credential.oauth_verifier = parameters["oauth_verifier"]!
+                    }
                     self.postOAuthAccessTokenWithRequestToken({
                         credential, response in
                         success(credential: credential, response: response)

--- a/OAuthSwiftDemo/AppDelegate.swift
+++ b/OAuthSwiftDemo/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWebViewDelegate {
         println(url)
         if (url.host == "oauth-callback") {
             if (url.path!.hasPrefix("/twitter") || url.path!.hasPrefix("/flickr") || url.path!.hasPrefix("/fitbit")
-             || url.path!.hasPrefix("/withings") || url.path!.hasPrefix("/linkedin")) {
+             || url.path!.hasPrefix("/withings") || url.path!.hasPrefix("/linkedin") || url.path!.hasPrefix("/smugmug")) {
                 OAuth1Swift.handleOpenURL(url)
             }
             if ( url.path!.hasPrefix("/github" ) || url.path!.hasPrefix("/instagram" ) || url.path!.hasPrefix("/foursquare") || url.path!.hasPrefix("/dropbox") || url.path!.hasPrefix("/dribbble") ) {

--- a/OAuthSwiftDemo/Constants.swift
+++ b/OAuthSwiftDemo/Constants.swift
@@ -58,3 +58,8 @@ let Dribbble =
     "consumerKey": "***",
     "consumerSecret": "***"
 ]
+let Smugmug =
+[
+    "consumerKey": "***",
+    "consumerSecret": "***"
+]

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -11,7 +11,7 @@ import OAuthSwift
 
 class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Dropbox", "Dribbble"]
+    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Dropbox", "Dribbble", "Smugmug"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -181,7 +181,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
-    
+
     func doOAuthLinkedin(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Linkedin["consumerKey"]!,
@@ -193,17 +193,35 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/linkedin")!, success: {
             credential, response in
             self.showAlertView("Linkedin", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-                var parameters =  Dictionary<String, AnyObject>()
-                oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
+            var parameters =  Dictionary<String, AnyObject>()
+            oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
                     success: {
                         data, response in
                         let dataString = NSString(data: data, encoding: NSUTF8StringEncoding)
                         println(dataString)
                     }, failure: {(error:NSError!) -> Void in
-                        println(error)
-                })
-            }, failure: {(error:NSError!) -> Void in
-                println(error.localizedDescription)
+                println(error)
+            })
+        }, failure: {(error:NSError!) -> Void in
+            println(error.localizedDescription)
+        })
+    }
+
+    func doOAuthSmugmug(){
+        let oauthswift = OAuth1Swift(
+            consumerKey:    Smugmug["consumerKey"]!,
+            consumerSecret: Smugmug["consumerSecret"]!,
+            requestTokenUrl: "http://api.smugmug.com/services/oauth/getRequestToken.mg",
+            authorizeUrl:    "http://api.smugmug.com/services/oauth/authorize.mg",
+            accessTokenUrl:  "http://api.smugmug.com/services/oauth/getAccessToken.mg"
+        )
+        oauthswift.allowMissingOauthVerifier = true
+        // NOTE: Smugmug's callback URL is configured on their site and the one passed in is ignored.
+        oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/smugmug")!, success: {
+            credential, response in
+            self.showAlertView("Smugmug", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
+        }, failure: {(error:NSError!) -> Void in
+            println(error.localizedDescription)
         })
     }
 
@@ -299,6 +317,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 doOAuthDropbox()
             case "Dribbble":
                 doOAuthDribbble();
+            case "Smugmug":
+                doOAuthSmugmug()
             default:
                 println("default (check ViewController tableView)")
         }


### PR DESCRIPTION
Optionally (defaulting to the spec-correct function) allow the skipping of the oauth_verifier to deal with non-spec-compliant oauth providers. SmugMug is such a provider. Some references to this can be found at http://www.dgrin.com/archive/index.php/t-212289.html (dgrin.com is smugmug's forum)

Thanks,
-George