### PR TITLE
Allow base authorizeUrl to contain query string

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -74,7 +74,7 @@ public class OAuth1Swift: NSObject {
                 }
             })
             // 2. Authorize
-            let queryURL = NSURL(string: self.authorize_url + "?oauth_token=\(credential.oauth_token)")
+            let queryURL = NSURL(string: self.authorize_url + (self.authorize_url.has("?") ? "&" : "?") + "oauth_token=\(credential.oauth_token)")
             if ( self.webViewController != nil ) {
                 if let webView = self.webViewController as? WebViewProtocol {
                     webView.setUrl(queryURL!)

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -79,7 +79,7 @@ public class OAuth2Swift: NSObject {
         //let authorizeURL = NSURL(string: )
         var urlString = String()
         urlString += self.authorize_url
-        urlString += "?client_id=\(self.consumer_key)"
+        urlString += (self.authorize_url.has("?") ? "&" : "?") + "client_id=\(self.consumer_key)"
         urlString += "&redirect_uri=\(callbackURL.absoluteString!)"
         urlString += "&response_type=\(self.response_type)"
         if (scope != "") {

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -172,7 +172,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             consumerKey:    Fitbit["consumerKey"]!,
             consumerSecret: Fitbit["consumerSecret"]!,
             requestTokenUrl: "https://api.fitbit.com/oauth/request_token",
-            authorizeUrl:    "https://www.fitbit.com/oauth/authorize",
+            authorizeUrl:    "https://www.fitbit.com/oauth/authorize?display=touch",
             accessTokenUrl:  "https://api.fitbit.com/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/fitbit")!, success: {


### PR DESCRIPTION
Currently, _OAuth1Swift_ and _OAuth2Swift_ append query string parameters to _authorizeUrl_ with no regard as to whether a query string already exists, resulting in URL's like http://example.com/oauth/authorize?display=touch?oauth_token=12345

This pull request changes this functionality to check to see if a _?_ is already present in the URL. If so, it will append a _&_ before further parameters, otherwise a _?_ is used.

I've also updated the FitBit demo to pass in the display=touch parameter, as making that work was the whole point of this modification.