### PR TITLE
fix code extraction for webview

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -59,7 +59,7 @@ public class OAuth2Swift: NSObject {
             if ((url.query) != nil){
                 parameters = url.query!.parametersFromQueryString()
             }
-            if ((url.fragment) != nil){
+            if ((url.fragment) != nil && url.fragment!.isEmpty == false) {
                 parameters = url.fragment!.parametersFromQueryString()
             }
             if (parameters["access_token"] != nil){


### PR DESCRIPTION
When working with WebView test the url fragment is not nil AND is not an empty string. Since Swift 1.2 a cast is done in String that can now contains empty string.