### PR TITLE
Add OSX, better way to present custom web controller, fix one bug

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -2,13 +2,14 @@ Pod::Spec.new do |s|
   s.name = 'OAuthSwift'
   s.version = '0.3.4'
   s.license = 'MIT'
-  s.summary = 'Swift based OAuth library for iOS.'
+  s.summary = 'Swift based OAuth library for iOS and OSX.'
   s.homepage = 'https://github.com/dongri/OAuthSwift'
   s.social_media_url = 'http://twitter.com/dongriat'
   s.authors = { 'Dongri Jin' => 'dongriat@gmail.com' }
   s.source = { :git => 'https://github.com/dongri/OAuthSwift.git', :tag => s.version }
   s.source_files = 'OAuthSwift/*.swift'
-  s.platform = :ios, '8.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
   s.requires_arc = false
 end
 

--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,29 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C48B28071AFA598D00C7DEF6 /* OAuthSwiftOSX.h in Headers */ = {isa = PBXBuildFile; fileRef = C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C48B28211AFA599400C7DEF6 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
+		C48B28221AFA599700C7DEF6 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
+		C48B28231AFA599A00C7DEF6 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
+		C48B28241AFA599A00C7DEF6 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */; };
+		C48B28251AFA599A00C7DEF6 /* OAuthSwiftHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */; };
+		C48B28261AFA599A00C7DEF6 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599AE1A78FFAF004A96C1 /* Utils.swift */; };
+		C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599AC1A78FF23004A96C1 /* SHA1.swift */; };
+		C48B28281AFA599A00C7DEF6 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599B21A7901DF004A96C1 /* HMAC.swift */; };
+		C48B28291AFA599A00C7DEF6 /* Dictionary+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4805E1E1A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift */; };
+		C48B282A1AFA599A00C7DEF6 /* NSURL+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4805E1F1A6BB5DD00F7677E /* NSURL+OAuthSwift.swift */; };
+		C48B282B1AFA599A00C7DEF6 /* String+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */; };
+		C48B282C1AFA599A00C7DEF6 /* NSData+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599B01A79001B004A96C1 /* NSData+OAuthSwift.swift */; };
+		C48B282D1AFA599C00C7DEF6 /* Int+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599B41A7903C9004A96C1 /* Int+OAuthSwift.swift */; };
+		C496246F1B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */; };
+		C49624701B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */; };
+		C49624721B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */; };
+		C49624731B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */; };
+		C49FD5291AFB5DF500791E1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49FD5281AFB5DF500791E1A /* AppDelegate.swift */; };
+		C49FD52B1AFB5DF500791E1A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49FD52A1AFB5DF500791E1A /* ViewController.swift */; };
+		C49FD5301AFB5DF500791E1A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C49FD52E1AFB5DF500791E1A /* Main.storyboard */; };
+		C49FD5451AFB619100791E1A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F454D53019772AE500354060 /* Constants.swift */; };
+		C49FD5471AFB623000791E1A /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49FD5461AFB623000791E1A /* WebViewController.swift */; };
 		F422B2D91A67B2A20060A70F /* OAuthSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; };
 		F42F57D91A67F2040064249F /* OAuthSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F435027F1A6791B200038A29 /* OAuthSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = F435027E1A6791B200038A29 /* OAuthSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -24,7 +47,6 @@
 		F4805E231A6BB5DD00F7677E /* String+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */; };
 		F490AA261A67EA7D00765D10 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F490AA281A67EA7D00765D10 /* InfoPlist.strings */; };
 		F4C1D03D1A8A5D5000CAF356 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1D03C1A8A5D5000CAF356 /* WebViewController.swift */; };
-		F4C1D03F1A8A64D400CAF356 /* OAuthWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1D03E1A8A64D400CAF356 /* OAuthWebViewController.swift */; };
 		F4E9A4DC1A67944C00B4F3C8 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		F4E9A4DD1A67944C00B4F3C8 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		F4E9A4DE1A67944C00B4F3C8 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
@@ -45,6 +67,13 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		C49FD5431AFB60F100791E1A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F451E3BD195B8CD80051434C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C48B28011AFA598D00C7DEF6;
+			remoteInfo = OAuthSwiftOSX;
+		};
 		F42F57DA1A67F2040064249F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F451E3BD195B8CD80051434C /* Project object */;
@@ -69,6 +98,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwiftOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C48B28051AFA598D00C7DEF6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAuthSwiftOSX.h; sourceTree = "<group>"; };
+		C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthWebViewController.swift; sourceTree = "<group>"; };
+		C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftURLHandlerType.swift; sourceTree = "<group>"; };
+		C49FD5241AFB5DF500791E1A /* OAuthSwiftOSXDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuthSwiftOSXDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C49FD5271AFB5DF500791E1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C49FD5281AFB5DF500791E1A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C49FD52A1AFB5DF500791E1A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C49FD52F1AFB5DF500791E1A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		C49FD5461AFB623000791E1A /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		F43502681A6790EC00038A29 /* OAuth1Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth1Swift.swift; sourceTree = "<group>"; };
 		F43502691A6790EC00038A29 /* OAuth2Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2Swift.swift; sourceTree = "<group>"; };
 		F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftClient.swift; sourceTree = "<group>"; };
@@ -94,10 +134,23 @@
 		F490AA271A67EA7D00765D10 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F490AA291A67EAE900765D10 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F4C1D03C1A8A5D5000CAF356 /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
-		F4C1D03E1A8A64D400CAF356 /* OAuthWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthWebViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		C48B27FE1AFA598D00C7DEF6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C49FD5211AFB5DF500791E1A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F43502761A6791B200038A29 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -116,6 +169,55 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C48B28031AFA598D00C7DEF6 /* OAuthSwiftOSX */ = {
+			isa = PBXGroup;
+			children = (
+				C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */,
+				C48B28041AFA598D00C7DEF6 /* Supporting Files */,
+			);
+			path = OAuthSwiftOSX;
+			sourceTree = "<group>";
+		};
+		C48B28041AFA598D00C7DEF6 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				C48B28051AFA598D00C7DEF6 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		C49624741B00F8240010BD09 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F4805E1E1A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift */,
+				F4805E1F1A6BB5DD00F7677E /* NSURL+OAuthSwift.swift */,
+				F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */,
+				F47599B01A79001B004A96C1 /* NSData+OAuthSwift.swift */,
+				F47599B41A7903C9004A96C1 /* Int+OAuthSwift.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		C49FD5251AFB5DF500791E1A /* OAuthSwiftOSXDemo */ = {
+			isa = PBXGroup;
+			children = (
+				C49FD5281AFB5DF500791E1A /* AppDelegate.swift */,
+				C49FD52A1AFB5DF500791E1A /* ViewController.swift */,
+				C49FD5461AFB623000791E1A /* WebViewController.swift */,
+				C49FD52E1AFB5DF500791E1A /* Main.storyboard */,
+				C49FD5261AFB5DF500791E1A /* Supporting Files */,
+			);
+			path = OAuthSwiftOSXDemo;
+			sourceTree = "<group>";
+		};
+		C49FD5261AFB5DF500791E1A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				C49FD5271AFB5DF500791E1A /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		F435027B1A6791B200038A29 /* OAuthSwift */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,16 +226,13 @@
 				F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */,
 				F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */,
 				F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */,
+				C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */,
+				C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */,
 				F47599AE1A78FFAF004A96C1 /* Utils.swift */,
 				F47599AC1A78FF23004A96C1 /* SHA1.swift */,
 				F47599B21A7901DF004A96C1 /* HMAC.swift */,
-				F4805E1E1A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift */,
-				F4805E1F1A6BB5DD00F7677E /* NSURL+OAuthSwift.swift */,
-				F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */,
-				F47599B01A79001B004A96C1 /* NSData+OAuthSwift.swift */,
-				F47599B41A7903C9004A96C1 /* Int+OAuthSwift.swift */,
+				C49624741B00F8240010BD09 /* Extensions */,
 				F435027E1A6791B200038A29 /* OAuthSwift.h */,
-				F4C1D03E1A8A64D400CAF356 /* OAuthWebViewController.swift */,
 				F435027C1A6791B200038A29 /* Supporting Files */,
 			);
 			path = OAuthSwift;
@@ -152,6 +251,8 @@
 			children = (
 				F435027B1A6791B200038A29 /* OAuthSwift */,
 				F451E3E2195B8D030051434C /* OAuthSwiftDemo */,
+				C48B28031AFA598D00C7DEF6 /* OAuthSwiftOSX */,
+				C49FD5251AFB5DF500791E1A /* OAuthSwiftOSXDemo */,
 				F451E3C6195B8CD80051434C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -161,6 +262,8 @@
 			children = (
 				F451E3C5195B8CD80051434C /* OAuthSwiftDemo.app */,
 				F435027A1A6791B200038A29 /* OAuthSwift.framework */,
+				C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */,
+				C49FD5241AFB5DF500791E1A /* OAuthSwiftOSXDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -182,6 +285,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		C48B27FF1AFA598D00C7DEF6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C48B28071AFA598D00C7DEF6 /* OAuthSwiftOSX.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F43502771A6791B200038A29 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -193,6 +304,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C48B281F1AFA598D00C7DEF6 /* Build configuration list for PBXNativeTarget "OAuthSwiftOSX" */;
+			buildPhases = (
+				C48B27FD1AFA598D00C7DEF6 /* Sources */,
+				C48B27FE1AFA598D00C7DEF6 /* Frameworks */,
+				C48B27FF1AFA598D00C7DEF6 /* Headers */,
+				C48B28001AFA598D00C7DEF6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OAuthSwiftOSX;
+			productName = OAuthSwiftOSX;
+			productReference = C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C49FD5231AFB5DF500791E1A /* OAuthSwiftOSXDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C49FD5411AFB5DF500791E1A /* Build configuration list for PBXNativeTarget "OAuthSwiftOSXDemo" */;
+			buildPhases = (
+				C49FD5201AFB5DF500791E1A /* Sources */,
+				C49FD5211AFB5DF500791E1A /* Frameworks */,
+				C49FD5221AFB5DF500791E1A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C49FD5441AFB60F100791E1A /* PBXTargetDependency */,
+			);
+			name = OAuthSwiftOSXDemo;
+			productName = OAuthSwiftOSXDemo;
+			productReference = C49FD5241AFB5DF500791E1A /* OAuthSwiftOSXDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		F43502791A6791B200038A29 /* OAuthSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F435028D1A6791B200038A29 /* Build configuration list for PBXNativeTarget "OAuthSwift" */;
@@ -240,6 +387,12 @@
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Dongri Jin";
 				TargetAttributes = {
+					C48B28011AFA598D00C7DEF6 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+					C49FD5231AFB5DF500791E1A = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
 					F43502791A6791B200038A29 = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
@@ -255,6 +408,7 @@
 			knownRegions = (
 				en,
 				ja,
+				Base,
 			);
 			mainGroup = F451E3BC195B8CD80051434C;
 			productRefGroup = F451E3C6195B8CD80051434C /* Products */;
@@ -263,11 +417,28 @@
 			targets = (
 				F451E3C4195B8CD80051434C /* OAuthSwiftDemo */,
 				F43502791A6791B200038A29 /* OAuthSwift */,
+				C49FD5231AFB5DF500791E1A /* OAuthSwiftOSXDemo */,
+				C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		C48B28001AFA598D00C7DEF6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C49FD5221AFB5DF500791E1A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C49FD5301AFB5DF500791E1A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F43502781A6791B200038A29 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -287,6 +458,39 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		C48B27FD1AFA598D00C7DEF6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C48B28221AFA599700C7DEF6 /* OAuth2Swift.swift in Sources */,
+				C48B28251AFA599A00C7DEF6 /* OAuthSwiftHTTPRequest.swift in Sources */,
+				C48B28211AFA599400C7DEF6 /* OAuth1Swift.swift in Sources */,
+				C48B282B1AFA599A00C7DEF6 /* String+OAuthSwift.swift in Sources */,
+				C49624731B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */,
+				C48B28241AFA599A00C7DEF6 /* OAuthSwiftCredential.swift in Sources */,
+				C48B282A1AFA599A00C7DEF6 /* NSURL+OAuthSwift.swift in Sources */,
+				C48B282C1AFA599A00C7DEF6 /* NSData+OAuthSwift.swift in Sources */,
+				C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */,
+				C48B28231AFA599A00C7DEF6 /* OAuthSwiftClient.swift in Sources */,
+				C48B28281AFA599A00C7DEF6 /* HMAC.swift in Sources */,
+				C48B282D1AFA599C00C7DEF6 /* Int+OAuthSwift.swift in Sources */,
+				C48B28261AFA599A00C7DEF6 /* Utils.swift in Sources */,
+				C48B28291AFA599A00C7DEF6 /* Dictionary+OAuthSwift.swift in Sources */,
+				C49624701B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C49FD5201AFB5DF500791E1A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C49FD52B1AFB5DF500791E1A /* ViewController.swift in Sources */,
+				C49FD5291AFB5DF500791E1A /* AppDelegate.swift in Sources */,
+				C49FD5451AFB619100791E1A /* Constants.swift in Sources */,
+				C49FD5471AFB623000791E1A /* WebViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F43502751A6791B200038A29 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,6 +499,7 @@
 				F4E9A4DD1A67944C00B4F3C8 /* OAuth2Swift.swift in Sources */,
 				F47599B31A7901DF004A96C1 /* HMAC.swift in Sources */,
 				F4805E231A6BB5DD00F7677E /* String+OAuthSwift.swift in Sources */,
+				C49624721B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */,
 				F4E9A4DE1A67944C00B4F3C8 /* OAuthSwiftClient.swift in Sources */,
 				F4E9A4DF1A67944C00B4F3C8 /* OAuthSwiftCredential.swift in Sources */,
 				F47599AF1A78FFAF004A96C1 /* Utils.swift in Sources */,
@@ -304,7 +509,7 @@
 				F47599B51A7903C9004A96C1 /* Int+OAuthSwift.swift in Sources */,
 				F4805E211A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift in Sources */,
 				F47599B11A79001B004A96C1 /* NSData+OAuthSwift.swift in Sources */,
-				F4C1D03F1A8A64D400CAF356 /* OAuthWebViewController.swift in Sources */,
+				C496246F1B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -322,6 +527,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		C49FD5441AFB60F100791E1A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */;
+			targetProxy = C49FD5431AFB60F100791E1A /* PBXContainerItemProxy */;
+		};
 		F42F57DB1A67F2040064249F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F43502791A6791B200038A29 /* OAuthSwift */;
@@ -330,6 +540,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		C49FD52E1AFB5DF500791E1A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C49FD52F1AFB5DF500791E1A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
 		F490AA281A67EA7D00765D10 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -342,6 +560,98 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		C48B281B1AFA598D00C7DEF6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = OAuthSwiftOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C48B281C1AFA598D00C7DEF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = OAuthSwiftOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C49FD53D1AFB5DF500791E1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = OAuthSwiftOSXDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		C49FD53E1AFB5DF500791E1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = OAuthSwiftOSXDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		F435028E1A6791B200038A29 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -514,6 +824,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C48B281F1AFA598D00C7DEF6 /* Build configuration list for PBXNativeTarget "OAuthSwiftOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C48B281B1AFA598D00C7DEF6 /* Debug */,
+				C48B281C1AFA598D00C7DEF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C49FD5411AFB5DF500791E1A /* Build configuration list for PBXNativeTarget "OAuthSwiftOSXDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C49FD53D1AFB5DF500791E1A /* Debug */,
+				C49FD53E1AFB5DF500791E1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F435028D1A6791B200038A29 /* Build configuration list for PBXNativeTarget "OAuthSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwift.xcscheme
+++ b/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwift.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:OAuthSwift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F43502831A6791B200038A29"
-               BuildableName = "OAuthSwiftTests.xctest"
-               BlueprintName = "OAuthSwiftTests"
-               ReferencedContainer = "container:OAuthSwift.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -42,16 +28,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F43502831A6791B200038A29"
-               BuildableName = "OAuthSwiftTests.xctest"
-               BlueprintName = "OAuthSwiftTests"
-               ReferencedContainer = "container:OAuthSwift.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -7,14 +7,12 @@
 //
 
 import Foundation
-import UIKit
 
 public class OAuth2Swift: NSObject {
 
     public var client: OAuthSwiftClient
 
-    public var webViewController: UIViewController?
-
+    public var authorize_url_handler: OAuthSwiftURLHandlerType = OAuthSwiftOpenURLExternally.sharedInstance
 
     var consumer_key: String
     var consumer_secret: String
@@ -92,15 +90,8 @@ public class OAuth2Swift: NSObject {
             urlString += "&\(param.0)=\(param.1)"
         }
 
-        let queryURL = NSURL(string: urlString)
-        if ( self.webViewController != nil ) {
-            if let webView = self.webViewController as? WebViewProtocol {
-                webView.setUrl(queryURL!)
-                UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(
-                    self.webViewController!, animated: true, completion: nil)
-            }
-        } else {
-            UIApplication.sharedApplication().openURL(queryURL!)
+        if let queryURL = NSURL(string: urlString) {
+           self.authorize_url_handler.handle(queryURL)
         }
     }
     

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-import UIKit
-
 public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
     
     public typealias SuccessHandler = (data: NSData, response: NSHTTPURLResponse) -> Void

--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -1,0 +1,34 @@
+//
+//  OAuthSwiftURLHandlerType.swift
+//  OAuthSwift
+//
+//  Created by phimage on 11/05/15.
+//  Copyright (c) 2015 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+@objc public protocol OAuthSwiftURLHandlerType {
+    func handle(url: NSURL)
+}
+
+public class OAuthSwiftOpenURLExternally: OAuthSwiftURLHandlerType {
+    class var sharedInstance : OAuthSwiftOpenURLExternally {
+        struct Static {
+            static var onceToken : dispatch_once_t = 0
+            static var instance : OAuthSwiftOpenURLExternally? = nil
+        }
+        dispatch_once(&Static.onceToken) {
+            Static.instance = OAuthSwiftOpenURLExternally()
+        }
+        return Static.instance!
+    }
+    
+    @objc public func handle(url: NSURL) {
+        #if os(iOS)
+            UIApplication.sharedApplication().openURL(url)
+        #elseif os(OSX)
+            NSWorkspace.sharedWorkspace().openURL(url)
+        #endif
+    }
+}

--- a/OAuthSwift/OAuthWebViewController.swift
+++ b/OAuthSwift/OAuthWebViewController.swift
@@ -1,5 +1,5 @@
 //
-//  WebView.swift
+//  OAuthWebViewController.swift
 //  OAuthSwift
 //
 //  Created by Dongri Jin on 2/11/15.
@@ -8,12 +8,43 @@
 
 import Foundation
 
-import UIKit
+#if os(iOS)
+    import UIKit
+    public typealias OAuthViewController = UIViewController
+#elseif os(OSX)
+    import AppKit
+    public typealias OAuthViewController = NSViewController
+#endif
 
-@objc protocol WebViewProtocol {
-    func setUrl(url: NSURL)
-}
+public class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerType {
 
-public class OAuthWebViewController: UIViewController, WebViewProtocol {
-    public func setUrl(url: NSURL){}
+    public func handle(url: NSURL){
+        #if os(iOS)
+            UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(
+                self, animated: true, completion: nil)
+        #elseif os(OSX)
+            if let p = self.parentViewController { // default behaviour if this controller affected as child controller
+                p.presentViewControllerAsModalWindow(self)
+            } else if let window = self.view.window {
+                window.makeKeyAndOrderFront(nil)
+            }
+            // or create an NSWindow or NSWindowController (/!\ keep a strong reference on it)
+        #endif
+    }
+
+    public func dismissWebViewController() {
+        #if os(iOS)
+            self.dismissViewControllerAnimated(true, completion: nil)
+        #elseif os(OSX)
+            if let p = self.presentingViewController { // if presentViewControllerAsModalWindow
+                self.dismissController(nil)
+                if let p = self.parentViewController {
+                    self.removeFromParentViewController()
+                }
+            }
+            else if let window = self.view.window {
+                window.performClose(nil)
+            }
+        #endif
+    }
 }

--- a/OAuthSwiftDemo/WebViewController.swift
+++ b/OAuthSwiftDemo/WebViewController.swift
@@ -24,8 +24,9 @@ class WebViewController: OAuthWebViewController, UIWebViewDelegate {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    override func setUrl(url: NSURL) {
+    override func handle(url: NSURL) {
         targetURL = url
+        super.handle(url)
     }
     func loadAddressURL() {
         let req = NSURLRequest(URL: targetURL)
@@ -33,7 +34,7 @@ class WebViewController: OAuthWebViewController, UIWebViewDelegate {
     }
     func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
         if (request.URL!.scheme == "oauth-swift"){
-            self.dismissViewControllerAnimated(true, completion: nil)
+            self.dismissWebViewController()
         }
         return true
     }

--- a/OAuthSwiftOSX/Info.plist
+++ b/OAuthSwiftOSX/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>tv.phimage.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 Dongri Jin. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/OAuthSwiftOSX/OAuthSwiftOSX.h
+++ b/OAuthSwiftOSX/OAuthSwiftOSX.h
@@ -1,0 +1,19 @@
+//
+//  OAuthSwiftOSX.h
+//  OAuthSwiftOSX
+//
+//  Created by phimage on 06/05/15.
+//  Copyright (c) 2015 Dongri Jin. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for OAuthSwiftOSX.
+FOUNDATION_EXPORT double OAuthSwiftOSXVersionNumber;
+
+//! Project version string for OAuthSwiftOSX.
+FOUNDATION_EXPORT const unsigned char OAuthSwiftOSXVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <OAuthSwiftOSX/PublicHeader.h>
+
+

--- a/OAuthSwiftOSXDemo/AppDelegate.swift
+++ b/OAuthSwiftOSXDemo/AppDelegate.swift
@@ -1,0 +1,54 @@
+//
+//  AppDelegate.swift
+//  OAuthSwiftOSXDemo
+//
+//  Created by phimage on 07/05/15.
+//  Copyright (c) 2015 Dongri Jin. All rights reserved.
+//
+
+import Cocoa
+import OAuthSwiftOSX
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+
+
+    func applicationDidFinishLaunching(aNotification: NSNotification) {
+        
+        NSAppleEventManager.sharedAppleEventManager().setEventHandler(self, andSelector:"handleGetURLEvent:withReplyEvent:", forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
+    }
+
+    func applicationWillTerminate(aNotification: NSNotification) {
+        // Insert code here to tear down your application
+    }
+
+    private func handleGetURLEvent(event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor)
+    {
+        if let urlString = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue, url = NSURL(string: urlString) {
+            applicationHandleOpenURL(url)
+        }
+    }
+    
+    internal func applicationHandleOpenURL(url: NSURL) {
+        println(url)
+        if (url.host == "oauth-callback") {
+            if (url.path!.hasPrefix("/twitter") || url.path!.hasPrefix("/flickr") || url.path!.hasPrefix("/fitbit")
+                || url.path!.hasPrefix("/withings") || url.path!.hasPrefix("/linkedin") || url.path!.hasPrefix("/bitbucket") || url.path!.hasPrefix("/smugmug") || url.path!.hasPrefix("/intuit") || url.path!.hasPrefix("/trello") ) {
+                    OAuth1Swift.handleOpenURL(url)
+            }
+            if ( url.path!.hasPrefix("/github" ) || url.path!.hasPrefix("/instagram" ) || url.path!.hasPrefix("/foursquare") || url.path!.hasPrefix("/dropbox") || url.path!.hasPrefix("/dribbble") || url.path!.hasPrefix("/salesforce") || url.path!.hasPrefix("/google") || url.path!.hasPrefix("/linkedin2")) {
+                OAuth2Swift.handleOpenURL(url)
+            }
+        } else {
+            // Google provider is the only one wuth your.bundle.id url schema.
+            OAuth2Swift.handleOpenURL(url)
+        }
+    }
+    
+    class var sharedInstance: AppDelegate {
+        return NSApplication.sharedApplication().delegate as! AppDelegate
+    }
+
+}
+

--- a/OAuthSwiftOSXDemo/Base.lproj/Main.storyboard
+++ b/OAuthSwiftOSXDemo/Base.lproj/Main.storyboard
@@ -1,0 +1,764 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14C109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="OAuthSwiftOSXDemo" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="OAuthSwiftOSXDemo" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About OAuthSwiftOSXDemo" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide OAuthSwiftOSXDemo" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit OAuthSwiftOSXDemo" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" id="KaW-ft-85H">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="OAuthSwiftOSXDemo Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="OAuthSwiftOSXDemo" customModuleProvider="target"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="OAuthSwiftOSXDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5fX-vd-A3n">
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                                <clipView key="contentView" misplaced="YES" id="mLI-uc-0WC">
+                                    <rect key="frame" x="1" y="0.0" width="238" height="134"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="6aN-zR-PVb" viewBased="YES" id="YJ1-YI-Equ">
+                                            <rect key="frame" x="0.0" y="0.0" width="479" height="0.0"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn width="475.15344328292002" minWidth="40" maxWidth="1000" id="knT-Up-5lZ">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="bqU-oC-nkf">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="8nw-RP-Pzb">
+                                                            <rect key="frame" x="1" y="1" width="475.60452846363728" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="xIm-hC-jck">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="477" height="17"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="7j0-pk-xon">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <binding destination="8nw-RP-Pzb" name="value" keyPath="objectValue" id="56r-QR-TXa"/>
+                                                                    </connections>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="xIm-hC-jck" firstAttribute="leading" secondItem="8nw-RP-Pzb" secondAttribute="leading" constant="2" id="cnm-Dn-oYO"/>
+                                                                <constraint firstItem="xIm-hC-jck" firstAttribute="centerY" secondItem="8nw-RP-Pzb" secondAttribute="centerY" id="css-Oi-6vD"/>
+                                                                <constraint firstAttribute="trailing" secondItem="xIm-hC-jck" secondAttribute="trailing" id="hGy-LE-EFt"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="xIm-hC-jck" id="wMl-Mj-wsi"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <outlet property="dataSource" destination="XfG-lQ-9wD" id="RCP-K9-YdC"/>
+                                                <outlet property="delegate" destination="XfG-lQ-9wD" id="yKy-Mf-HHm"/>
+                                            </connections>
+                                        </tableView>
+                                    </subviews>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.99999999999999423" horizontal="YES" id="5jd-KN-o2t">
+                                    <rect key="frame" x="1" y="119" width="223" height="15"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="4he-3P-vkr">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <tableHeaderView key="headerView" id="6aN-zR-PVb">
+                                    <rect key="frame" x="0.0" y="0.0" width="238" height="17"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableHeaderView>
+                            </scrollView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="5fX-vd-A3n" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" id="2bg-1e-jgZ"/>
+                            <constraint firstAttribute="trailing" secondItem="5fX-vd-A3n" secondAttribute="trailing" id="AgZ-8T-JFv"/>
+                            <constraint firstItem="5fX-vd-A3n" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="Pg5-k1-GdC"/>
+                            <constraint firstAttribute="bottom" secondItem="5fX-vd-A3n" secondAttribute="bottom" id="y6X-ud-K9V"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="103" y="674"/>
+        </scene>
+    </scenes>
+</document>

--- a/OAuthSwiftOSXDemo/Info.plist
+++ b/OAuthSwiftOSXDemo/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>tv.phimage.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>oauth-swift</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 Dongri Jin. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/OAuthSwiftOSXDemo/ViewController.swift
+++ b/OAuthSwiftOSXDemo/ViewController.swift
@@ -1,31 +1,53 @@
 //
 //  ViewController.swift
-//  OAuthSwift
+//  OAuthSwiftOSXDemo
 //
-//  Created by Dongri Jin on 6/21/14.
-//  Copyright (c) 2014 Dongri Jin. All rights reserved.
+//  Created by phimage on 07/05/15.
+//  Copyright (c) 2015 Dongri Jin. All rights reserved.
 //
 
-import UIKit
-import OAuthSwift
+import Cocoa
+import OAuthSwiftOSX
 
-class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSource {
 
     var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Linkedin2", "Dropbox", "Dribbble", "Salesforce", "BitBucket", "GoogleDrive", "Smugmug", "Intuit"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.title = "OAuth"
-        let tableView: UITableView = UITableView(frame: self.view.bounds, style: .Plain)
-        tableView.delegate = self
-        tableView.dataSource = self
-        self.view.addSubview(tableView);
+
+        // Do any additional setup after loading the view.
+    }
+    
+    func createWebViewController() -> WebViewController {
+        let controller = WebViewController()
+        controller.view = NSView(frame: NSRect(x:0, y:0, width: 450, height: 500)) // needed if no nib or not loaded from storyboard
+        controller.viewDidLoad()
+        return controller
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
+    func get_url_handler() -> OAuthSwiftURLHandlerType {
+        // Create a WebViewController with default behaviour from OAuthWebViewController
+        let url_handler = createWebViewController()
+        self.addChildViewController(url_handler) // allow WebViewController to use this ViewController as parent to be presented
+        return url_handler
+        
+        // a better way is 
+        // - to make this ViewController implement OAuthSwiftURLHandlerType and assigned in oauthswift object
+        /* return self */
+        // - have an instance of WebViewController here (I) or a segue name to launch (S)
+        // - in handle(url) 
+        //    (I) : affect url to WebViewController, and  self.presentViewControllerAsModalWindow(self.webViewController)
+        //    (S) : affect url to a temp variable (ex: urlForWebView), then perform segue
+        /* performSegueWithIdentifier("oauthwebview", sender:nil) */
+        //         then override prepareForSegue() to affect url to destination controller WebViewController
+        
     }
-
+    //(I)
+    //let webViewController: WebViewController = createWebViewController()
+    //(S)
+    //var urlForWebView:?NSURL = nil
+    
     func doOAuthTwitter(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Twitter["consumerKey"]!,
@@ -35,7 +57,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://api.twitter.com/oauth/access_token"
         )
         
-        //oauthswift.authorize_url_handler = WebViewController()
+        //oauthswift.authorize_url_handler = createWebViewController()
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/twitter")!, success: {
             credential, response in
             self.showAlertView("Twitter", message: "auth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
@@ -47,14 +69,14 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                     println(jsonDict)
                 }, failure: {(error:NSError!) -> Void in
                     println(error)
-                })
+            })
             
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
             }
         )
     }
-
+    
     func doOAuthFlickr(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Flickr["consumerKey"]!,
@@ -83,14 +105,14 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 }, failure: {(error:NSError!) -> Void in
                     println(error)
             })
-
-
-        }, failure: {(error:NSError!) -> Void in
-            println(error.localizedDescription)
+            
+            
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
         })
         
     }
-
+    
     func doOAuthGithub(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Github["consumerKey"]!,
@@ -105,7 +127,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             self.showAlertView("Github", message: "oauth_token:\(credential.oauth_token)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
-            })
+        })
         
     }
     
@@ -127,6 +149,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         
     }
 
+    
     func doOAuthInstagram(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Instagram["consumerKey"]!,
@@ -134,9 +157,9 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             authorizeUrl:   "https://api.instagram.com/oauth/authorize",
             responseType:   "token"
         )
-
+        
         let state: String = generateStateWithLength(20) as String
-        oauthswift.authorize_url_handler = WebViewController()
+        oauthswift.authorize_url_handler = get_url_handler()
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/instagram")!, scope: "likes+comments", state:state, success: {
             credential, response in
             self.showAlertView("Instagram", message: "oauth_token:\(credential.oauth_token)")
@@ -150,11 +173,11 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 }, failure: {(error:NSError!) -> Void in
                     println(error)
             })
-        }, failure: {(error:NSError!) -> Void in
-            println(error.localizedDescription)
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthFoursquare(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Foursquare["consumerKey"]!,
@@ -167,7 +190,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             self.showAlertView("Foursquare", message: "oauth_token:\(credential.oauth_token)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
-            })
+        })
     }
     
     func doOAuthFitbit(){
@@ -185,7 +208,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthWithings(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Withings["consumerKey"]!,
@@ -201,7 +224,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthLinkedin(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Linkedin["consumerKey"]!,
@@ -215,18 +238,18 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             self.showAlertView("Linkedin", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
-                    success: {
-                        data, response in
-                        let dataString = NSString(data: data, encoding: NSUTF8StringEncoding)
-                        println(dataString)
-                    }, failure: {(error:NSError!) -> Void in
-                println(error)
+                success: {
+                    data, response in
+                    let dataString = NSString(data: data, encoding: NSUTF8StringEncoding)
+                    println(dataString)
+                }, failure: {(error:NSError!) -> Void in
+                    println(error)
             })
-        }, failure: {(error:NSError!) -> Void in
-            println(error.localizedDescription)
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthLinkedin2(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Linkedin2["consumerKey"]!,
@@ -252,7 +275,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthSmugmug(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Smugmug["consumerKey"]!,
@@ -266,11 +289,11 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/smugmug")!, success: {
             credential, response in
             self.showAlertView("Smugmug", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-        }, failure: {(error:NSError!) -> Void in
-            println(error.localizedDescription)
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthDropbox(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Dropbox["consumerKey"]!,
@@ -279,7 +302,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl: "https://api.dropbox.com/1/oauth2/token",
             responseType:   "token"
         )
-        oauthswift.authorize_url_handler = WebViewController()
+        
+        oauthswift.authorize_url_handler = get_url_handler()
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/dropbox")!, scope: "", state: "", success: {
             credential, response in
             self.showAlertView("Dropbox", message: "oauth_token:\(credential.oauth_token)")
@@ -292,13 +316,13 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                     println(jsonDict)
                 }, failure: {(error:NSError!) -> Void in
                     println(error)
-                })
-
+            })
+            
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
         })
     }
-
+    
     func doOAuthDribbble(){
         let oauthswift = OAuth2Swift(
             consumerKey:    Dribbble["consumerKey"]!,
@@ -319,36 +343,36 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                     println(jsonDict)
                 }, failure: {(error:NSError!) -> Void in
                     println(error)
-                })
+            })
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
         })
     }
-
-	func doOAuthBitBucket(){
-		let oauthswift = OAuth1Swift(
-			consumerKey:    BitBucket["consumerKey"]!,
-			consumerSecret: BitBucket["consumerSecret"]!,
-			requestTokenUrl: "https://bitbucket.org/api/1.0/oauth/request_token",
-			authorizeUrl:    "https://bitbucket.org/api/1.0/oauth/authenticate",
-			accessTokenUrl:  "https://bitbucket.org/api/1.0/oauth/access_token"
-		)
-		oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/bitbucket")!, success: {
-			credential, response in
-			self.showAlertView("BitBucket", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-			var parameters =  Dictionary<String, AnyObject>()
-			oauthswift.client.get("https://bitbucket.org/api/1.0/user", parameters: parameters,
-				success: {
-					data, response in
-					let dataString = NSString(data: data, encoding: NSUTF8StringEncoding)
-					println(dataString)
-				}, failure: {(error:NSError!) -> Void in
-					println(error)
-			})
-			}, failure: {(error:NSError!) -> Void in
-				println(error.localizedDescription)
-		})
-	}
+    
+    func doOAuthBitBucket(){
+        let oauthswift = OAuth1Swift(
+            consumerKey:    BitBucket["consumerKey"]!,
+            consumerSecret: BitBucket["consumerSecret"]!,
+            requestTokenUrl: "https://bitbucket.org/api/1.0/oauth/request_token",
+            authorizeUrl:    "https://bitbucket.org/api/1.0/oauth/authenticate",
+            accessTokenUrl:  "https://bitbucket.org/api/1.0/oauth/access_token"
+        )
+        oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/bitbucket")!, success: {
+            credential, response in
+            self.showAlertView("BitBucket", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
+            var parameters =  Dictionary<String, AnyObject>()
+            oauthswift.client.get("https://bitbucket.org/api/1.0/user", parameters: parameters,
+                success: {
+                    data, response in
+                    let dataString = NSString(data: data, encoding: NSUTF8StringEncoding)
+                    println(dataString)
+                }, failure: {(error:NSError!) -> Void in
+                    println(error)
+            })
+            }, failure: {(error:NSError!) -> Void in
+                println(error.localizedDescription)
+        })
+    }
     
     func doOAuthGoogle(){
         let oauthswift = OAuth2Swift(
@@ -378,7 +402,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println("ERROR: \(error.localizedDescription)")
         })
     }
-
+    
     func doOAuthIntuit(){
         let oauthswift = OAuth1Swift(
             consumerKey:    Intuit["consumerKey"]!,
@@ -394,73 +418,82 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
-
+    
     func snapshot() -> NSData {
-        UIGraphicsBeginImageContext(self.view.frame.size)
-        self.view.layer.renderInContext(UIGraphicsGetCurrentContext())
-        let fullScreenshot = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        UIImageWriteToSavedPhotosAlbum(fullScreenshot, nil, nil, nil)
-        return  UIImageJPEGRepresentation(fullScreenshot, 0.5)
+        var rep: NSBitmapImageRep = self.view.bitmapImageRepForCachingDisplayInRect(self.view.bounds)!
+        self.view.cacheDisplayInRect(self.view.bounds, toBitmapImageRep:rep)
+        return rep.TIFFRepresentation!
     }
-
+    
     func showAlertView(title: String, message: String) {
-        var alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
-        alert.addAction(UIAlertAction(title: "Close", style: UIAlertActionStyle.Default, handler: nil))
-        self.presentViewController(alert, animated: true, completion: nil)
+        var alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButtonWithTitle("Close")
+        alert.runModal()
     }
 
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int  {
-        return services.count
+    // MARK: NSTableViewDataSource
+    
+    func numberOfRowsInTableView(tableView: NSTableView) -> Int {
+        return self.services.count
     }
     
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath:NSIndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = UITableViewCell(style: UITableViewCellStyle.Subtitle, reuseIdentifier: "Cell")
-        cell.textLabel?.text = services[indexPath.row]
-        return cell;
+    // MARK: NSTableViewDelegate
+    
+    func tableView(tableView: NSTableView, objectValueForTableColumn tableColumn: NSTableColumn?, row: Int) -> AnyObject? {
+        return self.services[row]
     }
     
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath:NSIndexPath) {
-        var service: String = services[indexPath.row]
-        switch service {
-            case "Twitter":
-                doOAuthTwitter()
-            case "Flickr":
-                doOAuthFlickr()
-            case "Github":
-                doOAuthGithub()
-            case "Instagram":
-                doOAuthInstagram()
-            case "Foursquare":
-                doOAuthFoursquare()
-            case "Fitbit":
-                doOAuthFitbit()
-            case "Withings":
-                doOAuthWithings()
-            case "Linkedin":
-                doOAuthLinkedin()
-            case "Linkedin2":
-                doOAuthLinkedin2()
-            case "Dropbox":
-                doOAuthDropbox()
-            case "Dribbble":
-                doOAuthDribbble()
-            case "Salesforce":
-                doOAuthSalesforce()
-            case "BitBucket":
-                doOAuthBitBucket()
-            case "GoogleDrive":
-                doOAuthGoogle()
-            case "Smugmug":
-                doOAuthSmugmug()
-            case "Intuit":
-                doOAuthIntuit()
-            default:
-                println("default (check ViewController tableView)")
+    func tableViewSelectionDidChange(notification: NSNotification) {
+        if let tableView = notification.object as? NSTableView {
+            let row = tableView.selectedRow
+            if  row != -1 {
+                
+                let service: String = self.services[row]
+                
+                switch service {
+                case "Twitter":
+                    doOAuthTwitter()
+                case "Flickr":
+                    doOAuthFlickr()
+                case "Github":
+                    doOAuthGithub()
+                case "Instagram":
+                    doOAuthInstagram()
+                case "Foursquare":
+                    doOAuthFoursquare()
+                case "Fitbit":
+                    doOAuthFitbit()
+                case "Withings":
+                    doOAuthWithings()
+                case "Linkedin":
+                    doOAuthLinkedin()
+                case "Linkedin2":
+                    doOAuthLinkedin2()
+                case "Dropbox":
+                    doOAuthDropbox()
+                case "Dribbble":
+                    doOAuthDribbble()
+                case "Salesforce":
+                    doOAuthSalesforce()
+                case "BitBucket":
+                    doOAuthBitBucket()
+                case "GoogleDrive":
+                    doOAuthGoogle()
+                case "Smugmug":
+                    doOAuthSmugmug()
+                case "Intuit":
+                    doOAuthIntuit()
+                default:
+                    println("default (check ViewController tableView)")
+                }
+                
+                tableView.deselectRow(row)
+            }
         }
-        tableView.deselectRowAtIndexPath(indexPath, animated:true)
     }
-    
-    
+
 }
+
 

--- a/OAuthSwiftOSXDemo/WebViewController.swift
+++ b/OAuthSwiftOSXDemo/WebViewController.swift
@@ -1,0 +1,66 @@
+//
+//  WebViewController.swift
+//  OAuthSwift
+//
+//  Created by phimage on 07/05/15.
+//  Copyright (c) 2015 Dongri Jin. All rights reserved.
+//
+
+import AppKit
+import OAuthSwiftOSX
+import WebKit
+
+class WebViewController: OAuthWebViewController {
+    
+    var targetURL : NSURL = NSURL()
+    let webView : WKWebView = WKWebView()
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.webView.frame = self.view.bounds
+        self.webView.navigationDelegate = self
+        
+        
+        self.webView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.webView)
+        self.view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("|-0-[view]-0-|", options: nil, metrics: nil, views: ["view":self.webView]))
+        self.view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-0-[view]-0-|", options: nil, metrics: nil, views: ["view":self.webView]))
+    }
+    
+    override func handle(url: NSURL) {
+        self.targetURL = url
+        super.handle(url)
+        
+        loadAddressURL()
+    }
+ 
+    func loadAddressURL() {
+        let req = NSURLRequest(URL: targetURL)
+        self.webView.loadRequest(req)
+    }
+
+    /* override func  webView(webView: WebView!, decidePolicyForNavigationAction actionInformation: [NSObject : AnyObject]!, request: NSURLRequest!, frame: WebFrame!, decisionListener listener: WebPolicyDecisionListener!) {
+        
+        if request.URL?.scheme == "oauth-swift" {
+           self.dismissWebViewController()
+        }
+
+    } */
+}
+
+extension WebViewController: WKNavigationDelegate {
+    
+    func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
+        
+        if let url = navigationAction.request.URL where url.scheme == "oauth-swift" {
+            AppDelegate.sharedInstance.applicationHandleOpenURL(url)
+            decisionHandler(.Cancel)
+            
+            self.dismissWebViewController()
+            return
+        }
+
+        decisionHandler(.Allow)
+    }
+}


### PR DESCRIPTION
1 / Fix OAuth1 if callback url returned by service has no query (only fragment)

2 / Add compatibility with OSX, add demo project inspired from iOS one (many code to factorise)

3/ Normally a controller is not responsible to choose its parent controller as you do with the code 
```swift
UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(
                        self.webViewController!, animated: true, completion: nil)
```
A parent controller, not only the root one, could do it (moreover this root controller doesn't exist in OSX)
Maybe the web view controller could be in a storyboard, a segue must be performed to show it (with maybe a custom animation)
Maybe a web view is already present in the application, and no web view must be shown, only and url update of the current one

That's why 
- I rename the protocol WebViewProtocol to OAuthSwiftURLHandlerType, move to its own file,
- Replace in OAuth objects the property webViewController by an authorize_url_handler: OAuthSwiftURLHandlerType
- Make a default implementation to open URL externally has you do if there is no webViewController assigned to the OAuth object

In consequence, no more UIKit(or AppKit for OSX) reference to the core framework
Users of framework can make their own code to show the web view which handle the url
OAuthWebViewController can always be extended with default behaviour (this object could be excluded from core framework and be part of a submodule in podspec)

