### PR TITLE
added yelp to demo

### DIFF
--- a/OAuthSwiftDemo/Constants.swift
+++ b/OAuthSwiftDemo/Constants.swift
@@ -98,4 +98,10 @@ let Tumblr =
     "consumerKey": "***",
     "consumerSecret": "***"
 ]
-
+let Yelp =
+[
+    "consumerKey": "***",
+    "consumerSecret": "***",
+    "accessToken": "***",
+    "accessTokenSecret": "***"
+]

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -11,7 +11,7 @@ import OAuthSwift
 
 class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Linkedin2", "Dropbox", "Dribbble", "Salesforce", "BitBucket", "GoogleDrive", "Smugmug", "Intuit", "Zaim", "Tumblr"]
+    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Linkedin2", "Dropbox", "Dribbble", "Salesforce", "BitBucket", "GoogleDrive", "Smugmug", "Intuit", "Zaim", "Tumblr", "Yelp"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -426,6 +426,28 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 println(error.localizedDescription)
         })
     }
+    
+    func doOAuthYelp(){
+        let oauthClient = OAuthSwiftClient(
+            consumerKey:        Yelp["consumerKey"]!,
+            consumerSecret:     Yelp["consumerSecret"]!,
+            accessToken:        Yelp["accessToken"]!,
+            accessTokenSecret:  Yelp["accessTokenSecret"]!
+        )
+        let params: [String: String] = [
+            "location": "San+Francisco",
+            "term": "seafood"
+        ]
+        oauthClient.get("http://api.yelp.com/v2/search",
+            parameters: params,
+            success: { (data, response) -> Void in
+                let json: NSDictionary = NSJSONSerialization.JSONObjectWithData(data, options: nil, error: nil) as! NSDictionary
+                println(json)
+                self.showAlertView("Yelp", message: "See console for results")
+            }) { (error) -> Void in
+                println("there was an error: \(error)")
+        }
+    }
 
     func snapshot() -> NSData {
         UIGraphicsBeginImageContext(self.view.frame.size)
@@ -491,6 +513,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                 doOAuthZaim()
             case "Tumblr":
                 doOAuthTumblr()
+            case "Yelp":
+                doOAuthYelp()
             default:
                 println("default (check ViewController tableView)")
         }

--- a/OAuthSwiftOSXDemo/ViewController.swift
+++ b/OAuthSwiftOSXDemo/ViewController.swift
@@ -11,7 +11,7 @@ import OAuthSwiftOSX
 
 class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSource {
 
-    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Linkedin2", "Dropbox", "Dribbble", "Salesforce", "BitBucket", "GoogleDrive", "Smugmug", "Intuit", "Zaim"]
+    var services = ["Twitter", "Flickr", "Github", "Instagram", "Foursquare", "Fitbit", "Withings", "Linkedin", "Linkedin2", "Dropbox", "Dribbble", "Salesforce", "BitBucket", "GoogleDrive", "Smugmug", "Intuit", "Zaim", "Yelp"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -434,6 +434,28 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
                 println(error.localizedDescription)
         })
     }
+    
+    func doOAuthYelp(){
+        let oauthClient = OAuthSwiftClient(
+            consumerKey:        Yelp["consumerKey"]!,
+            consumerSecret:     Yelp["consumerSecret"]!,
+            accessToken:        Yelp["accessToken"]!,
+            accessTokenSecret:  Yelp["accessTokenSecret"]!
+        )
+        let params: [String: String] = [
+            "location": "San+Francisco",
+            "term": "seafood"
+        ]
+        oauthClient.get("http://api.yelp.com/v2/search",
+            parameters: params,
+            success: { (data, response) -> Void in
+                let json: NSDictionary = NSJSONSerialization.JSONObjectWithData(data, options: nil, error: nil) as! NSDictionary
+                println(json)
+                self.showAlertView("Yelp", message: "See console for results")
+            }) { (error) -> Void in
+                println("there was an error: \(error)")
+        }
+    }
 
     func snapshot() -> NSData {
         var rep: NSBitmapImageRep = self.view.bitmapImageRepForCachingDisplayInRect(self.view.bounds)!
@@ -503,6 +525,8 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
                     doOAuthIntuit()
                 case "Zaim":
                     doOAuthZaim()
+                case "Yelp":
+                    doOAuthYelp()
                 default:
                     println("default (check ViewController tableView)")
                 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback
 * [Smugmug](https://smugmug.atlassian.net/wiki/display/API/OAuth)
 * [Intuit](https://developer.intuit.com/docs/0100_accounting/0060_authentication_and_authorization/oauth_management_api)
 * [Zaim](https://dev.zaim.net/home/api/authorize)
+* [Yelp](https://www.yelp.com/developers/documentation)
 
 ### Images
 


### PR DESCRIPTION
Nice addition to the demo since Yelp's OAuth works a bit differently from the rest. The token and token secret values are not dynamic, provided on a per developer basis. This skips right to using the `OAuthSwiftClient` class, setting all four values.