### PR TITLE
Allow to modify client attributes Fix #26

### DIFF
--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -18,7 +18,7 @@ public class OAuthSwiftClient {
         static let signatureMethod = "HMAC-SHA1"
     }
     
-    var credential: OAuthSwiftCredential
+    private(set) public var credential: OAuthSwiftCredential
     
     public init(consumerKey: String, consumerSecret: String) {
         self.credential = OAuthSwiftCredential(consumer_key: consumerKey, consumer_secret: consumerSecret)


### PR DESCRIPTION
to set a previously computed token
```swift        
oauthswift.client.credential.oauth_token = XXX
oauthswift.client.credential.oauth_token_secret = XXX
```

See #26, allow to set value already computed with previous session

