### PR TITLE
Passing along response parameters to the caller also for OAuth1

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -46,13 +46,13 @@ public class OAuth1Swift: NSObject {
         static let appOnlyAuthenticationErrorCode = 1
     }
 
-    public typealias TokenSuccessHandler = (credential: OAuthSwiftCredential, response: NSURLResponse) -> Void
+    public typealias TokenSuccessHandler = (credential: OAuthSwiftCredential, response: NSURLResponse, parameters: NSDictionary) -> Void
     public typealias FailureHandler = (error: NSError) -> Void
 
     // 0. Start
     public func authorizeWithCallbackURL(callbackURL: NSURL, success: TokenSuccessHandler, failure: ((error: NSError) -> Void)) {
         self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: {
-            credential, response in
+            credential, response, parameters in
 
             self.observer = NSNotificationCenter.defaultCenter().addObserverForName(CallbackNotification.notificationName, object: nil, queue: NSOperationQueue.mainQueue(), usingBlock:{
                 notification in
@@ -74,10 +74,7 @@ public class OAuth1Swift: NSObject {
                     if (parameters["oauth_verifier"] != nil) {
                         self.client.credential.oauth_verifier = parameters["oauth_verifier"]!
                     }
-                    self.postOAuthAccessTokenWithRequestToken({
-                        credential, response in
-                        success(credential: credential, response: response)
-                    }, failure: failure)
+                    self.postOAuthAccessTokenWithRequestToken(success, failure: failure)
                 } else {
                     let userInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString("Oauth problem.", comment: "")]
                     failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: userInfo))
@@ -103,7 +100,7 @@ public class OAuth1Swift: NSObject {
             let parameters = responseString.parametersFromQueryString()
             self.client.credential.oauth_token = parameters["oauth_token"]!
             self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!
-            success(credential: self.client.credential, response: response)
+            success(credential: self.client.credential, response: response, parameters: parameters)
         }, failure: failure)
     }
 
@@ -118,7 +115,7 @@ public class OAuth1Swift: NSObject {
             let parameters = responseString.parametersFromQueryString()
             self.client.credential.oauth_token = parameters["oauth_token"]!
             self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!
-            success(credential: self.client.credential, response: response)
+            success(credential: self.client.credential, response: response, parameters: parameters)
         }, failure: failure)
     }
 

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -66,10 +66,7 @@ public class OAuth2Swift: NSObject {
             }
             if let code = responseParameters["code"] {
                 self.postOAuthAccessTokenWithRequestTokenByCode(code.stringByRemovingPercentEncoding!,
-                    callbackURL:callbackURL,
-                    success: { credential, response, responseParameters in
-                        success(credential: credential, response: response, parameters: responseParameters)
-                }, failure: failure)
+                    callbackURL:callbackURL, success: success, failure: failure)
                     
             }
         })

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -37,7 +37,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         
         //oauthswift.authorize_url_handler = WebViewController()
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/twitter")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Twitter", message: "auth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.twitter.com/1.1/statuses/mentions_timeline.json", parameters: parameters,
@@ -64,7 +64,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://www.flickr.com/services/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/flickr")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Flickr", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             let url :String = "https://api.flickr.com/services/rest/"
             let parameters :Dictionary = [
@@ -179,7 +179,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://api.fitbit.com/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/fitbit")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Fitbit", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -195,7 +195,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://oauth.withings.com/account/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/withings")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Withings", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -211,7 +211,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://api.linkedin.com/uas/oauth/accessToken"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/linkedin")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Linkedin", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
@@ -264,7 +264,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         oauthswift.allowMissingOauthVerifier = true
         // NOTE: Smugmug's callback URL is configured on their site and the one passed in is ignored.
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/smugmug")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Smugmug", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
         }, failure: {(error:NSError!) -> Void in
             println(error.localizedDescription)
@@ -334,7 +334,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
 			accessTokenUrl:  "https://bitbucket.org/api/1.0/oauth/access_token"
 		)
 		oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/bitbucket")!, success: {
-			credential, response in
+			credential, response, parameters in
 			self.showAlertView("BitBucket", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
 			var parameters =  Dictionary<String, AnyObject>()
 			oauthswift.client.get("https://bitbucket.org/api/1.0/user", parameters: parameters,
@@ -388,7 +388,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://oauth.intuit.com/oauth/v1/get_access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/intuit")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Intuit", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -404,7 +404,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "https://api.zaim.net/v2/auth/access"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/zaim")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Zaim", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -420,7 +420,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             accessTokenUrl:  "http://www.tumblr.com/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/tumblr")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Tumblr", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)

--- a/OAuthSwiftOSXDemo/ViewController.swift
+++ b/OAuthSwiftOSXDemo/ViewController.swift
@@ -59,7 +59,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         
         //oauthswift.authorize_url_handler = createWebViewController()
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/twitter")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Twitter", message: "auth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.twitter.com/1.1/statuses/mentions_timeline.json", parameters: parameters,
@@ -86,7 +86,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://www.flickr.com/services/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/flickr")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Flickr", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             let url :String = "https://api.flickr.com/services/rest/"
             let parameters :Dictionary = [
@@ -202,7 +202,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://api.fitbit.com/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/fitbit")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Fitbit", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -218,7 +218,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://oauth.withings.com/account/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/withings")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Withings", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -234,7 +234,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://api.linkedin.com/uas/oauth/accessToken"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/linkedin")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Linkedin", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
@@ -287,7 +287,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.allowMissingOauthVerifier = true
         // NOTE: Smugmug's callback URL is configured on their site and the one passed in is ignored.
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/smugmug")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Smugmug", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -358,7 +358,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://bitbucket.org/api/1.0/oauth/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/bitbucket")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("BitBucket", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             var parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://bitbucket.org/api/1.0/user", parameters: parameters,
@@ -412,7 +412,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://oauth.intuit.com/oauth/v1/get_access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/intuit")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Intuit", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)
@@ -428,7 +428,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             accessTokenUrl:  "https://api.zaim.net/v2/auth/access"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/zaim")!, success: {
-            credential, response in
+            credential, response, parameters in
             self.showAlertView("Zaim", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
             }, failure: {(error:NSError!) -> Void in
                 println(error.localizedDescription)


### PR DESCRIPTION
Inspired from 647a3ab5a4d461acd9ab7620a9fad5c34c44eb1a (add parameters for OAuth2 into TokenSuccessHandler) and to keep the coherence, I have hadded `parameters` to `TokenSuccessHandler` for OAuth1