### PR TITLE
Fix #94 set credential oauth2 var to true  when succeeding to connect…

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -69,6 +69,7 @@ public class OAuth2Swift: NSObject {
             }
             if let accessToken = responseParameters["access_token"] {
                 self.client.credential.oauth_token = accessToken
+                self.client.credential.oauth2 = true
                 success(credential: self.client.credential, response: nil, parameters: responseParameters)
             }
             if let code = responseParameters["code"] {


### PR DESCRIPTION
… and server respond with access_token

If this var is not set to true in that specific case, authorization header will be the OAuth1 one when making request