### PR TITLE
Fix error: `'parentViewController' is only available on OS X 10.10 or…

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/dongri/OAuthSwift.git', :tag => s.version }
   s.source_files = 'OAuthSwift/*.swift'
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '10.10'
   s.requires_arc = false
 end
 


### PR DESCRIPTION
I'm set deployment_target 10.10 :smiley: 