### PR TITLE
OS X BuildableName

### DIFF
--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -100,7 +100,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwiftOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C48B28051AFA598D00C7DEF6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAuthSwiftOSX.h; sourceTree = "<group>"; };
 		C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthWebViewController.swift; sourceTree = "<group>"; };
@@ -265,7 +265,7 @@
 			children = (
 				F451E3C5195B8CD80051434C /* OAuthSwiftDemo.app */,
 				F435027A1A6791B200038A29 /* OAuthSwift.framework */,
-				C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */,
+				C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */,
 				C49FD5241AFB5DF500791E1A /* OAuthSwiftOSXDemo.app */,
 			);
 			name = Products;
@@ -323,7 +323,7 @@
 			);
 			name = OAuthSwiftOSX;
 			productName = OAuthSwiftOSX;
-			productReference = C48B28021AFA598D00C7DEF6 /* OAuthSwiftOSX.framework */;
+			productReference = C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		C49FD5231AFB5DF500791E1A /* OAuthSwiftOSXDemo */ = {
@@ -590,7 +590,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "tv.phimage.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = OAuthSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -617,7 +617,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "tv.phimage.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = OAuthSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwiftOSX.xcscheme
+++ b/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwiftOSX.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C48B28011AFA598D00C7DEF6"
-               BuildableName = "OAuthSwiftOSX.framework"
+               BuildableName = "OAuthSwift.framework"
                BlueprintName = "OAuthSwiftOSX"
                ReferencedContainer = "container:OAuthSwift.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C48B28011AFA598D00C7DEF6"
-            BuildableName = "OAuthSwiftOSX.framework"
+            BuildableName = "OAuthSwift.framework"
             BlueprintName = "OAuthSwiftOSX"
             ReferencedContainer = "container:OAuthSwift.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C48B28011AFA598D00C7DEF6"
-            BuildableName = "OAuthSwiftOSX.framework"
+            BuildableName = "OAuthSwift.framework"
             BlueprintName = "OAuthSwiftOSX"
             ReferencedContainer = "container:OAuthSwift.xcodeproj">
          </BuildableReference>

--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -6,7 +6,13 @@
 //  Copyright (c) 2015 Dongri Jin. All rights reserved.
 //
 
-import AppKit
+import Foundation
+
+#if os(iOS)
+    import UIKit
+#elseif os(OSX)
+    import AppKit
+#endif
 
 @objc public protocol OAuthSwiftURLHandlerType {
     func handle(url: NSURL)

--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Dongri Jin. All rights reserved.
 //
 
-import Foundation
+import AppKit
 
 @objc public protocol OAuthSwiftURLHandlerType {
     func handle(url: NSURL)

--- a/OAuthSwiftOSXDemo/AppDelegate.swift
+++ b/OAuthSwiftOSXDemo/AppDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import OAuthSwiftOSX
+import OAuthSwift
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/OAuthSwiftOSXDemo/ViewController.swift
+++ b/OAuthSwiftOSXDemo/ViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import OAuthSwiftOSX
+import OAuthSwift
 
 class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSource {
 
@@ -61,7 +61,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/twitter")!, success: {
             credential, response in
             self.showAlertView("Twitter", message: "auth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.twitter.com/1.1/statuses/mentions_timeline.json", parameters: parameters,
                 success: {
                     data, response in
@@ -247,7 +247,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/linkedin")!, success: {
             credential, response in
             self.showAlertView("Linkedin", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.linkedin.com/v1/people/~", parameters: parameters,
                 success: {
                     data, response in
@@ -273,7 +273,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.authorizeWithCallbackURL( NSURL(string: "http://oauthswift.herokuapp.com/callback/linkedin2")!, scope: "r_fullprofile", state: state, success: {
             credential, response, parameters in
             self.showAlertView("Linkedin2", message: "oauth_token:\(credential.oauth_token)")
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.linkedin.com/v1/people/~?format=json", parameters: parameters,
                 success: {
                     data, response in
@@ -319,7 +319,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             credential, response, parameters in
             self.showAlertView("Dropbox", message: "oauth_token:\(credential.oauth_token)")
             // Get Dropbox Account Info
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.dropbox.com/1/account/info?access_token=\(credential.oauth_token)", parameters: parameters,
                 success: {
                     data, response in
@@ -350,7 +350,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
             credential, response, parameters in
             self.showAlertView("Dribbble", message: "oauth_token:\(credential.oauth_token)")
             // Get User
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://api.dribbble.com/v1/user?access_token=\(credential.oauth_token)", parameters: parameters,
                 success: {
                     data, response in
@@ -379,7 +379,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/bitbucket")!, success: {
             credential, response in
             self.showAlertView("BitBucket", message: "oauth_token:\(credential.oauth_token)\n\noauth_toke_secret:\(credential.oauth_token_secret)")
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             oauthswift.client.get("https://bitbucket.org/api/1.0/user", parameters: parameters,
                 success: {
                     data, response in
@@ -406,7 +406,7 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
         oauthswift.authorizeWithCallbackURL( NSURL(string: "https://oauthswift.herokuapp.com/callback/google")!, scope: "https://www.googleapis.com/auth/drive", state: "", success: {
             credential, response, parameters in
             self.showAlertView("Github", message: "oauth_token:\(credential.oauth_token)")
-            var parameters =  Dictionary<String, AnyObject>()
+            let parameters =  Dictionary<String, AnyObject>()
             // Multi-part upload
             oauthswift.client.postImage("https://www.googleapis.com/upload/drive/v2/files", parameters: parameters, image: self.snapshot(),
                 success: {
@@ -511,13 +511,13 @@ class ViewController: NSViewController , NSTableViewDelegate, NSTableViewDataSou
     }
 
     func snapshot() -> NSData {
-        var rep: NSBitmapImageRep = self.view.bitmapImageRepForCachingDisplayInRect(self.view.bounds)!
+        let rep: NSBitmapImageRep = self.view.bitmapImageRepForCachingDisplayInRect(self.view.bounds)!
         self.view.cacheDisplayInRect(self.view.bounds, toBitmapImageRep:rep)
         return rep.TIFFRepresentation!
     }
 
     func showAlertView(title: String, message: String) {
-        var alert = NSAlert()
+        let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = message
         alert.addButtonWithTitle("Close")

--- a/OAuthSwiftOSXDemo/WebViewController.swift
+++ b/OAuthSwiftOSXDemo/WebViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import AppKit
-import OAuthSwiftOSX
+import OAuthSwift
 import WebKit
 
 class WebViewController: OAuthWebViewController {


### PR DESCRIPTION
BuildableName even OS X should be the OAuthSwift, because cocoapods will always generate a OAuthSwift.framework.