### PR TITLE
FIX #110 merge query and fragment parameters instead of choosing one

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -61,9 +61,10 @@ public class OAuth1Swift: NSObject {
                 let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
                 var parameters: Dictionary<String, String> = Dictionary()
                 if ((url.query) != nil){
-                    parameters = url.query!.parametersFromQueryString()
-                } else if ((url.fragment) != nil && url.fragment!.isEmpty == false) {
-                    parameters = url.fragment!.parametersFromQueryString()
+                    parameters += url.query!.parametersFromQueryString()
+                }
+                if ((url.fragment) != nil && url.fragment!.isEmpty == false) {
+                    parameters += url.fragment!.parametersFromQueryString()
                 }
                 if let token = parameters["token"] {
                     parameters["oauth_token"] = token

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -62,10 +62,10 @@ public class OAuth2Swift: NSObject {
             let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
             var responseParameters: Dictionary<String, String> = Dictionary()
             if let query = url.query {
-                responseParameters = query.parametersFromQueryString()
+                responseParameters += query.parametersFromQueryString()
             }
             if ((url.fragment) != nil && url.fragment!.isEmpty == false) {
-                responseParameters = url.fragment!.parametersFromQueryString()
+                responseParameters += url.fragment!.parametersFromQueryString()
             }
             if let accessToken = responseParameters["access_token"] {
                 self.client.credential.oauth_token = accessToken

--- a/OAuthSwift/Utils.swift
+++ b/OAuthSwift/Utils.swift
@@ -48,3 +48,16 @@ public func generateStateWithLength (len : Int) -> NSString {
     }
     return randomString
 }
+
+public extension Dictionary {
+    
+    mutating func merge<K, V>(dictionaries: Dictionary<K, V>...) {
+        for dict in dictionaries {
+            for (key, value) in dict {
+                self.updateValue(value as! Value, forKey: key as! Key)
+            }
+        }
+    }
+}
+
+public func +=<K, V> (inout left: [K : V], right: [K : V]) { left.merge(right) }


### PR DESCRIPTION
in oauth1 the `else`is removed like in oauth2

and parameters dictionary are merged for the two versions

see my comment in issue #110, there is another fix