### PR TITLE
change NSURLConnection to NSURLSession

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -8,39 +8,39 @@
 
 import Foundation
 
-public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
-    
+public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
+
     public typealias SuccessHandler = (data: NSData, response: NSHTTPURLResponse) -> Void
     public typealias FailureHandler = (error: NSError) -> Void
-    
+
     var URL: NSURL
     var HTTPMethod: String
     var HTTPBodyMultipart: NSData?
     var contentTypeMultipart: String?
-    
+
     var request: NSMutableURLRequest?
-    var connection: NSURLConnection!
-    
+    var session: NSURLSession!
+
     var headers: Dictionary<String, String>
     var parameters: Dictionary<String, AnyObject>
     var encodeParameters: Bool
-    
+
     var dataEncoding: NSStringEncoding
-    
+
     var timeoutInterval: NSTimeInterval
-    
+
     var HTTPShouldHandleCookies: Bool
-    
+
     var response: NSHTTPURLResponse!
     var responseData: NSMutableData
-    
+
     var successHandler: SuccessHandler?
     var failureHandler: FailureHandler?
-    
+
     convenience init(URL: NSURL) {
         self.init(URL: URL, method: "GET", parameters: [:])
     }
-    
+
     init(URL: NSURL, method: String, parameters: Dictionary<String, AnyObject>) {
         self.URL = URL
         self.HTTPMethod = method
@@ -52,7 +52,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         self.HTTPShouldHandleCookies = false
         self.responseData = NSMutableData()
     }
-    
+
     init(request: NSURLRequest) {
         self.request = request as? NSMutableURLRequest
         self.URL = request.URL!
@@ -65,33 +65,34 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         self.HTTPShouldHandleCookies = false
         self.responseData = NSMutableData()
     }
-    
+
     func start() {
         if (request == nil) {
             var error: NSError?
-            
+
             do {
                 self.request = try OAuthSwiftHTTPRequest.makeRequest(self.URL, method: self.HTTPMethod, headers: self.headers, parameters: self.parameters, dataEncoding: self.dataEncoding, encodeParameters: self.encodeParameters, body: self.HTTPBodyMultipart, contentType: self.contentTypeMultipart)
             } catch let error1 as NSError {
                 error = error1
                 self.request = nil
             }
-                
+
             if ((error) != nil) {
                 print(error!.localizedDescription)
             }
         }
-        
+
         dispatch_async(dispatch_get_main_queue()) {
-            self.connection = NSURLConnection(request: self.request!, delegate: self)
-            self.connection.start()
-            
+            self.session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
+                delegate: self,
+                delegateQueue: nil)
+
             #if os(iOS)
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = true
             #endif
         }
     }
-    
+
     public class func makeRequest(        URL: NSURL,
         method: String,
         headers: [String : String],
@@ -100,18 +101,18 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         encodeParameters: Bool,
         body: NSData? = nil,
         contentType: String? = nil) throws -> NSMutableURLRequest {
-        var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
+            var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
             let request = NSMutableURLRequest(URL: URL)
             request.HTTPMethod = method
-            
+
             for (key, value) in headers {
                 request.setValue(value, forHTTPHeaderField: key)
             }
-            
+
             let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(dataEncoding))
-            
+
             let nonOAuthParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
-            
+
             if (body != nil && contentType != nil) {
                 request.setValue(contentType!, forHTTPHeaderField: "Content-Type")
                 //request!.setValue(self.HTTPBodyMultipart!.length.description, forHTTPHeaderField: "Content-Length")
@@ -150,64 +151,49 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
             return request
     }
-    
 
-    public func connection(connection: NSURLConnection, didReceiveResponse response: NSURLResponse) {
-        self.response = response as? NSHTTPURLResponse
-        
-        self.responseData.length = 0
-    }
-    
-    public func connection(connection: NSURLConnection, didSendBodyData bytesWritten: Int, totalBytesWritten: Int, totalBytesExpectedToWrite: Int) {
-    }
-    
-    public func connection(connection: NSURLConnection, didReceiveData data: NSData) {
-        self.responseData.appendData(data)
-    }
-    
-    public func connection(connection: NSURLConnection, didFailWithError error: NSError) {
-        #if os(iOS)
-            UIApplication.sharedApplication().networkActivityIndicatorVisible = false
-        #endif
-        
-        self.failureHandler?(error: error)
-    }
-    
-    public func connectionDidFinishLoading(connection: NSURLConnection) {
-        #if os(iOS)
-            UIApplication.sharedApplication().networkActivityIndicatorVisible = false
-        #endif
-        
-        if self.response.statusCode >= 400 {
-            let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
-            let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as String)
-            let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
-            let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
-            self.failureHandler?(error: error)
-            return
+    public func URLSession(session: NSURLSession, didBecomeInvalidWithError error: NSError?) {
+        session.dataTaskWithRequest(request!) { data, response, error -> Void in
+            #if os(iOS)
+                UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+            #endif
+
+            self.response = response as? NSHTTPURLResponse
+            self.responseData.length = 0
+            self.responseData.appendData(data!)
+
+            if self.response.statusCode >= 400 {
+                let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
+                let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as String)
+                let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
+                let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
+                self.failureHandler?(error: error)
+                return
+            }
+
+            self.successHandler?(data: self.responseData, response: self.response)
+            self.failureHandler?(error: error!)
         }
-        
-        self.successHandler?(data: self.responseData, response: self.response)
     }
-    
+
     class func stringWithData(data: NSData, encodingName: String?) -> String {
         var encoding: UInt = NSUTF8StringEncoding
-        
+
         if (encodingName != nil) {
             let encodingNameString = encodingName! as NSString
             encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding(encodingNameString))
-            
+
             if encoding == UInt(kCFStringEncodingInvalidId) {
                 encoding = NSUTF8StringEncoding // by default
             }
         }
-        
+
         return NSString(data: data, encoding: encoding)! as String
     }
-    
+
     class func descriptionForHTTPStatus(status: Int, responseString: String) -> String {
         var s = "HTTP Status \(status)"
-        
+
         var description: String?
         // http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
         if status == 400 { description = "Bad Request" }
@@ -251,7 +237,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         if status == 509 { description = "Unassigned" }
         if status == 510 { description = "Not Extended" }
         if status == 511 { description = "Network Authentication Required" }
-        
+
         if (description != nil) {
             s = s + ": " + description! + ", Response: " + responseString
         }

--- a/OAuthSwiftDemo/WebViewController.swift
+++ b/OAuthSwiftDemo/WebViewController.swift
@@ -15,7 +15,7 @@ class WebViewController: OAuthWebViewController, UIWebViewDelegate {
     let webView : UIWebView = UIWebView()
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.webView.frame = UIScreen.mainScreen().applicationFrame
+        self.webView.frame = UIScreen.mainScreen().bounds
         self.webView.scalesPageToFit = true
         self.webView.delegate = self
         self.view.addSubview(self.webView)


### PR DESCRIPTION
fixed: OAuthSwiftHTTPRequest.swift:86:31: 'init(request:delegate:)' was deprecated in iOS 9.0: Use NSURLSession (see NSURLSession.h)
![xcode warning](https://cloud.githubusercontent.com/assets/3256161/10121445/52ccae22-651e-11e5-8d06-b1a4f7bd5595.png)
