### PR TITLE
Move dico extensions from Util to good file

### DIFF
--- a/OAuthSwift/Dictionary+OAuthSwift.swift
+++ b/OAuthSwift/Dictionary+OAuthSwift.swift
@@ -48,5 +48,15 @@ extension Dictionary {
 
         return parts.joinWithSeparator("&") as String
     }
-    
+
+    mutating func merge<K, V>(dictionaries: Dictionary<K, V>...) {
+        for dict in dictionaries {
+            for (key, value) in dict {
+                self.updateValue(value as! Value, forKey: key as! Key)
+            }
+        }
+    }
 }
+
+public func +=<K, V> (inout left: [K : V], right: [K : V]) { left.merge(right) }
+public func +<K, V> (left: [K : V], right: [K : V]) -> [K : V] { return left.join(right) }

--- a/OAuthSwift/Utils.swift
+++ b/OAuthSwift/Utils.swift
@@ -48,16 +48,3 @@ public func generateStateWithLength (len : Int) -> NSString {
     }
     return randomString
 }
-
-public extension Dictionary {
-    
-    mutating func merge<K, V>(dictionaries: Dictionary<K, V>...) {
-        for dict in dictionaries {
-            for (key, value) in dict {
-                self.updateValue(value as! Value, forKey: key as! Key)
-            }
-        }
-    }
-}
-
-public func +=<K, V> (inout left: [K : V], right: [K : V]) { left.merge(right) }


### PR DESCRIPTION
In my previous PR I put dictionary merge function into Util.swift
I don't see extensions files into collapsed group Extensions

So this commit just move into the good place and add operator + that use dictionary join function