### PR TITLE
Allow to use OAuthSwift with custom network call or other network API

### DIFF
--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -12,12 +12,7 @@ import Accounts
 var dataEncoding: NSStringEncoding = NSUTF8StringEncoding
 
 public class OAuthSwiftClient {
-    
-    struct OAuth {
-        static let version = "1.0"
-        static let signatureMethod = "HMAC-SHA1"
-    }
-    
+
     private(set) public var credential: OAuthSwiftCredential
     
     public init(consumerKey: String, consumerSecret: String) {
@@ -50,46 +45,33 @@ public class OAuthSwiftClient {
         self.request(urlString, method: "PATCH", parameters: parameters, success: success, failure: failure)
     }
 
-    func request(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-
-        if let url = NSURL(string: url) {
-        
-            let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters)
-            if self.credential.oauth2 {
-                request.headers = ["Authorization": "Bearer \(self.credential.oauth_token)"]
-            } else {
-                request.headers = ["Authorization": OAuthSwiftClient.authorizationHeaderForMethod(method, url: url, parameters: parameters, credential: self.credential)]
-            }
+    public func request(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+        if let request = makeRequest(url, method: method, parameters: parameters) {
             
             request.successHandler = success
             request.failureHandler = failure
-            request.dataEncoding = dataEncoding
-            request.encodeParameters = true
             request.start()
         }
-
     }
-    
+
+    public func makeRequest(urlString: String, method: String, parameters: Dictionary<String, AnyObject>) -> OAuthSwiftHTTPRequest? {
+        if let url = NSURL(string: urlString) {
+            let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters)
+            request.headers = self.credential.makeHeaders(url, method: method, parameters: parameters)
+            request.dataEncoding = dataEncoding
+            request.encodeParameters = true
+            return request
+        }
+        return nil
+    }
+
     public func postImage(urlString: String, parameters: Dictionary<String, AnyObject>, image: NSData, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         self.multiPartRequest(urlString, method: "POST", parameters: parameters, image: image, success: success, failure: failure)
     }
-    
+
     func multiPartRequest(url: String, method: String, parameters: Dictionary<String, AnyObject>, image: NSData, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        
-        
-        if let url = NSURL(string: url) {
-        
-            let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters)
-            if self.credential.oauth2 {
-                request.headers = ["Authorization": "Bearer \(self.credential.oauth_token)"]
-            } else {
-                request.headers = ["Authorization": OAuthSwiftClient.authorizationHeaderForMethod(method, url: url, parameters: parameters, credential: self.credential)]
-            }
-            request.successHandler = success
-            request.failureHandler = failure
-            request.dataEncoding = dataEncoding
-            request.encodeParameters = true
-            
+
+        if let request = makeRequest(url, method: method, parameters: parameters) {
             
             var parmaImage = [String: AnyObject]()
             parmaImage["media"] = image
@@ -99,11 +81,13 @@ public class OAuthSwiftClient {
             
             request.HTTPBodyMultipart = body
             request.contentTypeMultipart = type
+            
+            request.successHandler = success
+            request.failureHandler = failure
             request.start()
         }
-        
     }
-    
+
     public func multiPartBodyFromParams(parameters: [String: AnyObject], boundary: String) -> NSData {
         let data = NSMutableData()
         
@@ -145,12 +129,8 @@ public class OAuthSwiftClient {
     }
 
     public func postMultiPartRequest(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        if let url = NSURL(string: url) {
-            let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters)
-            request.successHandler = success
-            request.failureHandler = failure
-            request.dataEncoding = dataEncoding
-            request.encodeParameters = true
+        
+        if let request = makeRequest(url, method: method, parameters: parameters) {
 
             let boundary = "POST-boundary-\(arc4random())-\(arc4random())"
             let type = "multipart/form-data; boundary=\(boundary)"
@@ -158,6 +138,9 @@ public class OAuthSwiftClient {
 
             request.HTTPBodyMultipart = body
             request.contentTypeMultipart = type
+            
+            request.successHandler = success
+            request.failureHandler = failure
             request.start()
         }
     }
@@ -204,65 +187,13 @@ public class OAuthSwiftClient {
         return data
     }
 
+    @available(*, deprecated=0.4.6, message="Because method moved to OAuthSwiftCredential!")
     public class func authorizationHeaderForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
-        var authorizationParameters = Dictionary<String, AnyObject>()
-        authorizationParameters["oauth_version"] = OAuth.version
-        authorizationParameters["oauth_signature_method"] =  OAuth.signatureMethod
-        authorizationParameters["oauth_consumer_key"] = credential.consumer_key
-        authorizationParameters["oauth_timestamp"] = String(Int64(NSDate().timeIntervalSince1970))
-        authorizationParameters["oauth_nonce"] = (NSUUID().UUIDString as NSString).substringToIndex(8)
-        
-        if (credential.oauth_token != ""){
-            authorizationParameters["oauth_token"] = credential.oauth_token
-        }
-        
-        for (key, value) in parameters {
-            if key.hasPrefix("oauth_") {
-                authorizationParameters.updateValue(value, forKey: key)
-            }
-        }
-        
-        let combinedParameters = authorizationParameters.join(parameters)
-        
-        let finalParameters = combinedParameters
-        
-        authorizationParameters["oauth_signature"] = self.signatureForMethod(method, url: url, parameters: finalParameters, credential: credential)
-        
-        var parameterComponents = authorizationParameters.urlEncodedQueryStringWithEncoding(dataEncoding).componentsSeparatedByString("&") as [String]
-        parameterComponents.sortInPlace { $0 < $1 }
-        
-        var headerComponents = [String]()
-        for component in parameterComponents {
-            let subcomponent = component.componentsSeparatedByString("=") as [String]
-            if subcomponent.count == 2 {
-                headerComponents.append("\(subcomponent[0])=\"\(subcomponent[1])\"")
-            }
-        }
-        
-        return "OAuth " + headerComponents.joinWithSeparator(", ")
+        return credential.authorizationHeaderForMethod(method, url: url, parameters: parameters)
     }
     
+    @available(*, deprecated=0.4.6, message="Because method moved to OAuthSwiftCredential!")
     public class func signatureForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, credential: OAuthSwiftCredential) -> String {
-        var tokenSecret: NSString = ""
-        tokenSecret = credential.oauth_token_secret.urlEncodedStringWithEncoding(dataEncoding)
-        
-        let encodedConsumerSecret = credential.consumer_secret.urlEncodedStringWithEncoding(dataEncoding)
-        
-        let signingKey = "\(encodedConsumerSecret)&\(tokenSecret)"
-        
-        var parameterComponents = parameters.urlEncodedQueryStringWithEncoding(dataEncoding).componentsSeparatedByString("&") as [String]
-        parameterComponents.sortInPlace { $0 < $1 }
-        
-        let parameterString = parameterComponents.joinWithSeparator("&")
-        let encodedParameterString = parameterString.urlEncodedStringWithEncoding(dataEncoding)
-        
-        let encodedURL = url.absoluteString.urlEncodedStringWithEncoding(dataEncoding)
-        
-        let signatureBaseString = "\(method)&\(encodedURL)&\(encodedParameterString)"
-        
-        let key = signingKey.dataUsingEncoding(NSUTF8StringEncoding)!
-        let msg = signatureBaseString.dataUsingEncoding(NSUTF8StringEncoding)!
-        let sha1 = HMAC.sha1(key: key, message: msg)!
-        return sha1.base64EncodedStringWithOptions([])
+        return credential.signatureForMethod(method, url: url, parameters: parameters)
     }
 }

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -71,7 +71,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             var error: NSError?
             
             do {
-                self.request = try OAuthSwiftHTTPRequest.makeRequest(self.URL, method: self.HTTPMethod, headers: self.headers, parameters: self.parameters, dataEncoding: self.dataEncoding, encodeParameters: self.encodeParameters, body: self.HTTPBodyMultipart, contentType: self.contentTypeMultipart)
+                self.request = try self.makeRequest()
             } catch let error1 as NSError {
                 error = error1
                 self.request = nil
@@ -92,7 +92,12 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLConnectionDataDelegate {
         }
     }
     
-    public class func makeRequest(        URL: NSURL,
+    public func makeRequest() throws -> NSMutableURLRequest {
+        return try OAuthSwiftHTTPRequest.makeRequest(self.URL, method: self.HTTPMethod, headers: self.headers, parameters: self.parameters, dataEncoding: self.dataEncoding, encodeParameters: self.encodeParameters, body: self.HTTPBodyMultipart, contentType: self.contentTypeMultipart)
+    }
+    
+    public class func makeRequest(
+        URL: NSURL,
         method: String,
         headers: [String : String],
         parameters: Dictionary<String, AnyObject>,


### PR DESCRIPTION
- Factorising method to create `OAuthSwiftHTTPRequest`
- Move method about credential into `OAuthSwiftCredential` instead of `OAuthSwiftClient`
- Extract method to create headers from credential
- Add method to create `NSMutableURLRequest` from `OAuthSwiftHTTPRequest` (just calling the static one)

I have just extracting and moving codes, no change

With this public methods its now easy to create a custom `NSMutableURLRequest` with headers from credential, or just get the one created by this api

We can for instance use Alamofire like that
```swift
 extension OAuthSwiftHTTPRequest : URLRequestConvertible {

public var URLRequest: NSMutableURLRequest {
        return try! self.makeRequest()
}
```
or just by adding headers as parameter of `request` Alamofire function using `makeHeaders`new function from `OAuthSwiftCredential`