### PR TITLE
Split `makeRequest` to enable populating existing URLRequest

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -117,65 +117,68 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     public func makeRequest() throws -> NSMutableURLRequest {
         return try OAuthSwiftHTTPRequest.makeRequest(self.URL, method: self.HTTPMethod, headers: self.headers, parameters: self.parameters, dataEncoding: self.dataEncoding, encodeParameters: self.encodeParameters, body: self.HTTPBodyMultipart, contentType: self.contentTypeMultipart)
     }
-    
-    public class func makeRequest(
-        URL: NSURL,
-        method: String,
-        headers: [String : String],
-        parameters: Dictionary<String, AnyObject>,
-        dataEncoding: NSStringEncoding,
-        encodeParameters: Bool,
-        body: NSData? = nil,
-        contentType: String? = nil) throws -> NSMutableURLRequest {
-            var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
-            let request = NSMutableURLRequest(URL: URL)
-            request.HTTPMethod = method
 
-            for (key, value) in headers {
-                request.setValue(value, forHTTPHeaderField: key)
-            }
+    public class func makeRequest(URL: NSURL,
+                                  method: String,
+                                  headers: [String : String],
+                                  parameters: Dictionary<String, AnyObject>,
+                                  dataEncoding: NSStringEncoding,
+                                  encodeParameters: Bool,
+                                  body: NSData? = nil,
+                                  contentType: String? = nil) throws -> NSMutableURLRequest {
+        let request = NSMutableURLRequest(URL: URL)
+        request.HTTPMethod = method
+        return try setupRequestForOAuth(request,
+            headers: headers,
+            parameters: parameters,
+            dataEncoding: dataEncoding,
+            encodeParameters: encodeParameters,
+            body: body,
+            contentType: contentType)
+    }
 
-            let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(dataEncoding))
 
-            let nonOAuthParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
+    public class func setupRequestForOAuth(request: NSMutableURLRequest,
+                                           headers: [String : String],
+                                           parameters: Dictionary<String, AnyObject>,
+                                           dataEncoding: NSStringEncoding,
+                                           encodeParameters: Bool,
+                                           body: NSData? = nil,
+                                           contentType: String? = nil) throws -> NSMutableURLRequest {
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
 
-            if (body != nil && contentType != nil) {
-                request.setValue(contentType!, forHTTPHeaderField: "Content-Type")
-                //request!.setValue(self.HTTPBodyMultipart!.length.description, forHTTPHeaderField: "Content-Length")
-                request.HTTPBody = body!
-            } else {
-                if nonOAuthParameters.count > 0 {
-                    if request.HTTPMethod == "GET" || request.HTTPMethod == "HEAD" || request.HTTPMethod == "DELETE" {
+        let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(dataEncoding))
+
+        let nonOAuthParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
+
+        if (body != nil && contentType != nil) {
+            request.setValue(contentType!, forHTTPHeaderField: "Content-Type")
+            request.HTTPBody = body!
+        } else {
+            if nonOAuthParameters.count > 0 {
+                if request.HTTPMethod == "GET" || request.HTTPMethod == "HEAD" || request.HTTPMethod == "DELETE" {
+                    let queryString = nonOAuthParameters.urlEncodedQueryStringWithEncoding(dataEncoding)
+                    let URL = request.URL!
+                    request.URL = URL.URLByAppendingQueryString(queryString)
+                    request.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: "Content-Type")
+                }
+                else {
+                    if (encodeParameters) {
                         let queryString = nonOAuthParameters.urlEncodedQueryStringWithEncoding(dataEncoding)
-                        request.URL = URL.URLByAppendingQueryString(queryString)
                         request.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: "Content-Type")
+                        request.HTTPBody = queryString.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
                     }
                     else {
-                        if (encodeParameters) {
-                            let queryString = nonOAuthParameters.urlEncodedQueryStringWithEncoding(dataEncoding)
-                            //self.request!.URL = self.URL.URLByAppendingQueryString(queryString)
-                            request.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: "Content-Type")
-                            request.HTTPBody = queryString.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
-                        }
-                        else {
-                            var jsonError: NSError?
-                            do {
-                                let jsonData: NSData = try NSJSONSerialization.dataWithJSONObject(nonOAuthParameters, options: [])
-                                request.setValue("application/json; charset=\(charset)", forHTTPHeaderField: "Content-Type")
-                                request.HTTPBody = jsonData
-                            } catch let error1 as NSError {
-                                jsonError = error1
-                                if (true) {
-                                    //println(jsonError!.localizedDescription)
-                                    error = jsonError
-                                }
-                                throw error
-                            }
-                        }
+                        let jsonData = try NSJSONSerialization.dataWithJSONObject(nonOAuthParameters, options: [])
+                        request.setValue("application/json; charset=\(charset)", forHTTPHeaderField: "Content-Type")
+                        request.HTTPBody = jsonData
                     }
                 }
             }
-            return request
+        }
+        return request
     }
 
     class func stringWithData(data: NSData, encodingName: String?) -> String {


### PR DESCRIPTION
This adds a new class method `setupRequestForOAuth(_:)` to OAuthSwiftHTTPRequest that allows you to specify an existing url request. 