### PR TITLE
Add enum for HTTP Method and OAuth protocol version

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -14,6 +14,7 @@ public let OAuthSwiftErrorDomain = "oauthswift.error"
 public class OAuth1Swift: NSObject {
 
     public var client: OAuthSwiftClient
+    public var version: OAuthSwiftCredential.Version { return self.client.credential.version }
 
     public var authorize_url_handler: OAuthSwiftURLHandlerType = OAuthSwiftOpenURLExternally.sharedInstance
 
@@ -34,6 +35,7 @@ public class OAuth1Swift: NSObject {
         self.authorize_url = authorizeUrl
         self.access_token_url = accessTokenUrl
         self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
+        self.client.credential.version = .OAuth1
     }
 
     struct CallbackNotification {
@@ -75,10 +77,7 @@ public class OAuth1Swift: NSObject {
                     if (parameters["oauth_verifier"] != nil) {
                         self.client.credential.oauth_verifier = parameters["oauth_verifier"]!
                     }
-                    self.postOAuthAccessTokenWithRequestToken({
-                        credential, response in
-                        success(credential: credential, response: response)
-                    }, failure: failure)
+                    self.postOAuthAccessTokenWithRequestToken(success, failure: failure)
                 } else {
                     let userInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString("Oauth problem.", comment: "")]
                     failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: userInfo))
@@ -98,7 +97,6 @@ public class OAuth1Swift: NSObject {
         if let callbackURLString: String = callbackURL.absoluteString {
             parameters["oauth_callback"] = callbackURLString
         }
-        self.client.credential.oauth_header_type = "oauth1"
         self.client.post(self.request_token_url, parameters: parameters, success: {
             data, response in
             let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String!

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -11,6 +11,7 @@ import Foundation
 public class OAuth2Swift: NSObject {
 
     public var client: OAuthSwiftClient
+    public var version: OAuthSwiftCredential.Version { return self.client.credential.version }
 
     public var authorize_url_handler: OAuthSwiftURLHandlerType = OAuthSwiftOpenURLExternally.sharedInstance
 
@@ -39,6 +40,7 @@ public class OAuth2Swift: NSObject {
         self.authorize_url = authorizeUrl
         self.response_type = responseType
         self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
+        self.client.credential.version = .OAuth2
     }
     
     struct CallbackNotification {
@@ -73,10 +75,7 @@ public class OAuth2Swift: NSObject {
             }
             if let code = responseParameters["code"] {
                 self.postOAuthAccessTokenWithRequestTokenByCode(code.stringByRemovingPercentEncoding!,
-                    callbackURL:callbackURL,
-                    success: { credential, response, responseParameters in
-                        success(credential: credential, response: response, parameters: responseParameters)
-                }, failure: failure)
+                    callbackURL:callbackURL, success: success, failure: failure)
             }
             if let error = responseParameters["error"], error_description = responseParameters["error_description"] {
                 let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString(error, comment: error_description)]
@@ -114,7 +113,7 @@ public class OAuth2Swift: NSObject {
         parameters["redirect_uri"] = callbackURL.absoluteString.stringByRemovingPercentEncoding
         
         if self.content_type == "multipart/form-data" {
-            self.client.postMultiPartRequest(self.access_token_url!, method: "POST", parameters: parameters, success: {
+            self.client.postMultiPartRequest(self.access_token_url!, method: .POST, parameters: parameters, success: {
                 data, response in
                 let responseJSON: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.MutableContainers)
                 
@@ -132,7 +131,6 @@ public class OAuth2Swift: NSObject {
                 success(credential: self.client.credential, response: response, parameters: responseParameters)
                 }, failure: failure)
         } else {
-            self.client.credential.oauth_header_type = "oauth2"
             self.client.post(self.access_token_url!, parameters: parameters, success: {
                 data, response in
                 let responseJSON: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.MutableContainers)

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -26,26 +26,26 @@ public class OAuthSwiftClient {
     }
     
     public func get(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "GET", parameters: parameters, success: success, failure: failure)
+        self.request(urlString, method: .GET, parameters: parameters, success: success, failure: failure)
     }
     
     public func post(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "POST", parameters: parameters, success: success, failure: failure)
+        self.request(urlString, method: .POST, parameters: parameters, success: success, failure: failure)
     }
 
     public func put(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "PUT", parameters: parameters, success: success, failure: failure)
+        self.request(urlString, method: .PUT, parameters: parameters, success: success, failure: failure)
     }
 
     public func delete(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "DELETE", parameters: parameters, success: success, failure: failure)
+        self.request(urlString, method: .DELETE, parameters: parameters, success: success, failure: failure)
     }
 
     public func patch(urlString: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: "PATCH", parameters: parameters, success: success, failure: failure)
+        self.request(urlString, method: .PATCH, parameters: parameters, success: success, failure: failure)
     }
 
-    public func request(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         if let request = makeRequest(url, method: method, parameters: parameters) {
             
             request.successHandler = success
@@ -54,10 +54,10 @@ public class OAuthSwiftClient {
         }
     }
 
-    public func makeRequest(urlString: String, method: String, parameters: Dictionary<String, AnyObject>) -> OAuthSwiftHTTPRequest? {
+    public func makeRequest(urlString: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>) -> OAuthSwiftHTTPRequest? {
         if let url = NSURL(string: urlString) {
             let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters)
-            request.headers = self.credential.makeHeaders(url, method: method, parameters: parameters)
+            request.headers = self.credential.makeHeaders(url, method: method.rawValue, parameters: parameters)
             request.dataEncoding = dataEncoding
             request.encodeParameters = true
             return request
@@ -66,10 +66,10 @@ public class OAuthSwiftClient {
     }
 
     public func postImage(urlString: String, parameters: Dictionary<String, AnyObject>, image: NSData, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.multiPartRequest(urlString, method: "POST", parameters: parameters, image: image, success: success, failure: failure)
+        self.multiPartRequest(urlString, method: .POST, parameters: parameters, image: image, success: success, failure: failure)
     }
 
-    func multiPartRequest(url: String, method: String, parameters: Dictionary<String, AnyObject>, image: NSData, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    func multiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, image: NSData, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
 
         if let request = makeRequest(url, method: method, parameters: parameters) {
             
@@ -128,7 +128,7 @@ public class OAuthSwiftClient {
         return data
     }
 
-    public func postMultiPartRequest(url: String, method: String, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
         if let request = makeRequest(url, method: method, parameters: parameters) {
 

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -13,8 +13,12 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     public typealias SuccessHandler = (data: NSData, response: NSHTTPURLResponse) -> Void
     public typealias FailureHandler = (error: NSError) -> Void
 
+    public enum Method: String {
+        case GET, POST, PUT, DELETE, PATCH //, OPTIONS, HEAD, TRACE, CONNECT
+    }
+
     var URL: NSURL
-    var HTTPMethod: String
+    var HTTPMethod: Method
     var HTTPBodyMultipart: NSData?
     var contentTypeMultipart: String?
 
@@ -38,10 +42,10 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     var failureHandler: FailureHandler?
 
     convenience init(URL: NSURL) {
-        self.init(URL: URL, method: "GET", parameters: [:])
+        self.init(URL: URL, method: .GET, parameters: [:])
     }
 
-    init(URL: NSURL, method: String, parameters: Dictionary<String, AnyObject>) {
+    init(URL: NSURL, method: Method, parameters: Dictionary<String, AnyObject>) {
         self.URL = URL
         self.HTTPMethod = method
         self.headers = [:]
@@ -56,7 +60,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     init(request: NSURLRequest) {
         self.request = request as? NSMutableURLRequest
         self.URL = request.URL!
-        self.HTTPMethod = request.HTTPMethod!
+        self.HTTPMethod = Method(rawValue: request.HTTPMethod ?? "") ?? .GET
         self.headers = [:]
         self.parameters = [:]
         self.encodeParameters = false
@@ -120,7 +124,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     
     public class func makeRequest(
         URL: NSURL,
-        method: String,
+        method: Method,
         headers: [String : String],
         parameters: Dictionary<String, AnyObject>,
         dataEncoding: NSStringEncoding,
@@ -129,7 +133,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         contentType: String? = nil) throws -> NSMutableURLRequest {
             var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
             let request = NSMutableURLRequest(URL: URL)
-            request.HTTPMethod = method
+            request.HTTPMethod = method.rawValue
 
             for (key, value) in headers {
                 request.setValue(value, forHTTPHeaderField: key)


### PR DESCRIPTION
2 enum created instead of using string
- HTTP Method for request
- protocol version for credential (or other things)

protocol version into credential is initialised in `init` of `OAuthXXX` class, I don't see any reason to postpone that, but maybe I am wrong

and remove useless re-call of success callback with all param, just pass the callback