### PR TITLE
Fix crash where there is no data in the response.

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -91,6 +91,11 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
                 #endif
                 
+                guard data != nil else {
+                    self.failureHandler?( error: error ?? NSError(domain: NSURLErrorDomain, code:NSURLErrorUnknown, userInfo: nil))
+                    return
+                }
+                
                 self.response = response as? NSHTTPURLResponse
                 self.responseData.length = 0
                 self.responseData.appendData(data!)


### PR DESCRIPTION
check for valid `data`,  and if it's null, return calling the failure closure.