### PR TITLE
Split `makeRequest` to enable populating existing URLRequest and add testing target

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -11,6 +11,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.requires_arc = false
-  s.dependency 'OHHTTPStubs'
 end
 

--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.requires_arc = false
+  s.dependency 'OHHTTPStubs'
 end
 

--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3854596A1BDE40170076F348 /* OAuthSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385459691BDE40170076F348 /* OAuthSwiftTests.swift */; };
+		3854596C1BDE40170076F348 /* OAuthSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; };
+		385459731BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385459721BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift */; };
 		C48B28071AFA598D00C7DEF6 /* OAuthSwiftOSX.h in Headers */ = {isa = PBXBuildFile; fileRef = C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C48B28211AFA599400C7DEF6 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		C48B28221AFA599700C7DEF6 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
@@ -47,7 +50,7 @@
 		F4805E231A6BB5DD00F7677E /* String+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */; };
 		F490AA261A67EA7D00765D10 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F490AA281A67EA7D00765D10 /* InfoPlist.strings */; };
 		F4C1D03D1A8A5D5000CAF356 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1D03C1A8A5D5000CAF356 /* WebViewController.swift */; };
-		F4E6442B1BAAC110005E7F56 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4E6442A1BAAC110005E7F56 /* Launch Screen.storyboard */; settings = {ASSET_TAGS = (); }; };
+		F4E6442B1BAAC110005E7F56 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4E6442A1BAAC110005E7F56 /* Launch Screen.storyboard */; };
 		F4E9A4DC1A67944C00B4F3C8 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		F4E9A4DD1A67944C00B4F3C8 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		F4E9A4DE1A67944C00B4F3C8 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
@@ -69,6 +72,13 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		3854596D1BDE40170076F348 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F451E3BD195B8CD80051434C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F43502791A6791B200038A29;
+			remoteInfo = OAuthSwift;
+		};
 		C49FD5431AFB60F100791E1A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F451E3BD195B8CD80051434C /* Project object */;
@@ -100,6 +110,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		385459671BDE40170076F348 /* OAuthSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OAuthSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		385459691BDE40170076F348 /* OAuthSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSwiftTests.swift; sourceTree = "<group>"; };
+		3854596B1BDE40170076F348 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		385459721BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftHTTPRequestTests.swift; sourceTree = "<group>"; };
 		C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C48B28051AFA598D00C7DEF6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAuthSwiftOSX.h; sourceTree = "<group>"; };
@@ -140,6 +154,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		385459641BDE40170076F348 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3854596C1BDE40170076F348 /* OAuthSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C48B27FE1AFA598D00C7DEF6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -172,6 +194,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		385459681BDE40170076F348 /* OAuthSwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				385459721BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift */,
+				385459691BDE40170076F348 /* OAuthSwiftTests.swift */,
+				3854596B1BDE40170076F348 /* Info.plist */,
+			);
+			path = OAuthSwiftTests;
+			sourceTree = "<group>";
+		};
 		C48B28031AFA598D00C7DEF6 /* OAuthSwiftOSX */ = {
 			isa = PBXGroup;
 			children = (
@@ -256,6 +288,7 @@
 				F451E3E2195B8D030051434C /* OAuthSwiftDemo */,
 				C48B28031AFA598D00C7DEF6 /* OAuthSwiftOSX */,
 				C49FD5251AFB5DF500791E1A /* OAuthSwiftOSXDemo */,
+				385459681BDE40170076F348 /* OAuthSwiftTests */,
 				F451E3C6195B8CD80051434C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -267,6 +300,7 @@
 				F435027A1A6791B200038A29 /* OAuthSwift.framework */,
 				C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */,
 				C49FD5241AFB5DF500791E1A /* OAuthSwiftOSXDemo.app */,
+				385459671BDE40170076F348 /* OAuthSwiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -308,6 +342,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		385459661BDE40170076F348 /* OAuthSwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 385459711BDE40170076F348 /* Build configuration list for PBXNativeTarget "OAuthSwiftTests" */;
+			buildPhases = (
+				385459631BDE40170076F348 /* Sources */,
+				385459641BDE40170076F348 /* Frameworks */,
+				385459651BDE40170076F348 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3854596E1BDE40170076F348 /* PBXTargetDependency */,
+			);
+			name = OAuthSwiftTests;
+			productName = OAuthSwiftTests;
+			productReference = 385459671BDE40170076F348 /* OAuthSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C48B281F1AFA598D00C7DEF6 /* Build configuration list for PBXNativeTarget "OAuthSwiftOSX" */;
@@ -389,10 +441,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Dongri Jin";
 				TargetAttributes = {
+					385459661BDE40170076F348 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					C48B28011AFA598D00C7DEF6 = {
 						CreatedOnToolsVersion = 6.3.1;
 					};
@@ -425,11 +480,19 @@
 				F43502791A6791B200038A29 /* OAuthSwift */,
 				C49FD5231AFB5DF500791E1A /* OAuthSwiftOSXDemo */,
 				C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */,
+				385459661BDE40170076F348 /* OAuthSwiftTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		385459651BDE40170076F348 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C48B28001AFA598D00C7DEF6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -466,6 +529,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		385459631BDE40170076F348 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				385459731BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift in Sources */,
+				3854596A1BDE40170076F348 /* OAuthSwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C48B27FD1AFA598D00C7DEF6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -535,6 +607,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3854596E1BDE40170076F348 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F43502791A6791B200038A29 /* OAuthSwift */;
+			targetProxy = 3854596D1BDE40170076F348 /* PBXContainerItemProxy */;
+		};
 		C49FD5441AFB60F100791E1A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C48B28011AFA598D00C7DEF6 /* OAuthSwiftOSX */;
@@ -568,6 +645,35 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3854596F1BDE40170076F348 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = OAuthSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.finetail.OAuthSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		385459701BDE40170076F348 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = OAuthSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.finetail.OAuthSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		C48B281B1AFA598D00C7DEF6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -843,6 +949,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		385459711BDE40170076F348 /* Build configuration list for PBXNativeTarget "OAuthSwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3854596F1BDE40170076F348 /* Debug */,
+				385459701BDE40170076F348 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		C48B281F1AFA598D00C7DEF6 /* Build configuration list for PBXNativeTarget "OAuthSwiftOSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		C49FD5301AFB5DF500791E1A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C49FD52E1AFB5DF500791E1A /* Main.storyboard */; };
 		C49FD5451AFB619100791E1A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F454D53019772AE500354060 /* Constants.swift */; };
 		C49FD5471AFB623000791E1A /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49FD5461AFB623000791E1A /* WebViewController.swift */; };
+		D79C71388C9269B34819ABE2 /* Pods_OAuthSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2944F06CE0C2C4346F6C4A3A /* Pods_OAuthSwiftTests.framework */; };
 		F422B2D91A67B2A20060A70F /* OAuthSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; };
 		F42F57D91A67F2040064249F /* OAuthSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F435027F1A6791B200038A29 /* OAuthSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = F435027E1A6791B200038A29 /* OAuthSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -110,10 +111,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2944F06CE0C2C4346F6C4A3A /* Pods_OAuthSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OAuthSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		381D42A31BDE69C40047DCE1 /* libOHHTTPStubs.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libOHHTTPStubs.a; path = "Pods/../build/Debug-iphoneos/libOHHTTPStubs.a"; sourceTree = "<group>"; };
 		385459671BDE40170076F348 /* OAuthSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OAuthSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		385459691BDE40170076F348 /* OAuthSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSwiftTests.swift; sourceTree = "<group>"; };
 		3854596B1BDE40170076F348 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		385459721BDE40800076F348 /* OAuthSwiftHTTPRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftHTTPRequestTests.swift; sourceTree = "<group>"; };
+		4DB3DD104C51F3C607494D9C /* Pods-OAuthSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAuthSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
+		719F0A3BEB91A1F79727154E /* Pods-OAuthSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAuthSwiftTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		C48B28021AFA598D00C7DEF6 /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C48B28051AFA598D00C7DEF6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C48B28061AFA598D00C7DEF6 /* OAuthSwiftOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAuthSwiftOSX.h; sourceTree = "<group>"; };
@@ -159,6 +164,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3854596C1BDE40170076F348 /* OAuthSwift.framework in Frameworks */,
+				D79C71388C9269B34819ABE2 /* Pods_OAuthSwiftTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -194,6 +200,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1B979FD856C5348F4D0E1E02 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				381D42A31BDE69C40047DCE1 /* libOHHTTPStubs.a */,
+				2944F06CE0C2C4346F6C4A3A /* Pods_OAuthSwiftTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		385459681BDE40170076F348 /* OAuthSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -202,6 +217,15 @@
 				3854596B1BDE40170076F348 /* Info.plist */,
 			);
 			path = OAuthSwiftTests;
+			sourceTree = "<group>";
+		};
+		3CA31D4F4C3C54594D986B66 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4DB3DD104C51F3C607494D9C /* Pods-OAuthSwiftTests.debug.xcconfig */,
+				719F0A3BEB91A1F79727154E /* Pods-OAuthSwiftTests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		C48B28031AFA598D00C7DEF6 /* OAuthSwiftOSX */ = {
@@ -290,6 +314,8 @@
 				C49FD5251AFB5DF500791E1A /* OAuthSwiftOSXDemo */,
 				385459681BDE40170076F348 /* OAuthSwiftTests */,
 				F451E3C6195B8CD80051434C /* Products */,
+				3CA31D4F4C3C54594D986B66 /* Pods */,
+				1B979FD856C5348F4D0E1E02 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -346,9 +372,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 385459711BDE40170076F348 /* Build configuration list for PBXNativeTarget "OAuthSwiftTests" */;
 			buildPhases = (
+				9B9F45BEEDD92AA7323A5626 /* Check Pods Manifest.lock */,
 				385459631BDE40170076F348 /* Sources */,
 				385459641BDE40170076F348 /* Frameworks */,
 				385459651BDE40170076F348 /* Resources */,
+				EA3A57D520966D41E6FAC03E /* Embed Pods Frameworks */,
+				5F8BF456744F94AD3E6544A5 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -528,6 +557,54 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		5F8BF456744F94AD3E6544A5 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9B9F45BEEDD92AA7323A5626 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		EA3A57D520966D41E6FAC03E /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		385459631BDE40170076F348 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -647,12 +724,17 @@
 /* Begin XCBuildConfiguration section */
 		3854596F1BDE40170076F348 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4DB3DD104C51F3C607494D9C /* Pods-OAuthSwiftTests.debug.xcconfig */;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = OAuthSwiftTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.finetail.OAuthSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -661,6 +743,7 @@
 		};
 		385459701BDE40170076F348 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 719F0A3BEB91A1F79727154E /* Pods-OAuthSwiftTests.release.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -668,6 +751,10 @@
 				INFOPLIST_FILE = OAuthSwiftTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.finetail.OAuthSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -956,6 +1043,7 @@
 				385459701BDE40170076F348 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C48B281F1AFA598D00C7DEF6 /* Build configuration list for PBXNativeTarget "OAuthSwiftOSX" */ = {
 			isa = XCConfigurationList;

--- a/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwift.xcscheme
+++ b/OAuthSwift.xcodeproj/xcshareddata/xcschemes/OAuthSwift.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "385459661BDE40170076F348"
+               BuildableName = "OAuthSwiftTests.xctest"
+               BlueprintName = "OAuthSwiftTests"
+               ReferencedContainer = "container:OAuthSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/OAuthSwift.xcworkspace/contents.xcworkspacedata
+++ b/OAuthSwift.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:OAuthSwift.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -91,20 +91,23 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 #if os(iOS)
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
                 #endif
-                self.response = response
-                guard let response = self.response as? NSHTTPURLResponse where response.statusCode < 400
-                else {
-                    let responseString = NSString(data: self.responseData, encoding: self.dataEncoding) as! String
-                    let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString)
-                    let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
-                    let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
+                if let resp = response as? NSHTTPURLResponse {
+                    self.response = resp
+                    guard self.response.statusCode < 400
+                        else {
+                            let responseString = NSString(data: self.responseData, encoding: self.dataEncoding) as! String
+                            let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString)
+                            let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
+                            let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
+                            self.failureHandler?(error: error)
+                            return
+                    }
+                    self.responseData.length = 0
+                    self.responseData.appendData(data!)
+                    self.successHandler?(data: self.responseData, response: self.response)
+                } else if let error = error{
                     self.failureHandler?(error: error)
-                    return
                 }
-
-                self.responseData.length = 0
-                self.responseData.appendData(data!)
-                self.successHandler?(data: self.responseData, response: self.response)
             }
             task.resume()
 

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -91,18 +91,17 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 #if os(iOS)
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
                 #endif
-
-                guard let response = response as? NSHTTPURLResponse where response.statusCode < 400
+                self.response = response as? NSHTTPURLResponse
+                guard let response = self.response where response.statusCode < 400
                 else {
-                    let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
-                    let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as String)
+                    let responseString = NSString(data: self.responseData, encoding: self.dataEncoding) as! String
+                    let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString)
                     let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
                     let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
                     self.failureHandler?(error: error)
                     return
                 }
 
-                self.response = response
                 self.responseData.length = 0
                 self.responseData.appendData(data!)
                 self.successHandler?(data: self.responseData, response: self.response)

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -91,8 +91,8 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 #if os(iOS)
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
                 #endif
-                self.response = response as? NSHTTPURLResponse
-                guard let response = self.response where response.statusCode < 400
+                self.response = response
+                guard let response = self.response as? NSHTTPURLResponse where response.statusCode < 400
                 else {
                     let responseString = NSString(data: self.responseData, encoding: self.dataEncoding) as! String
                     let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString)

--- a/OAuthSwiftTests/Info.plist
+++ b/OAuthSwiftTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/OAuthSwiftTests/OAuthSwiftHTTPRequestTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftHTTPRequestTests.swift
@@ -1,0 +1,50 @@
+//
+//  OAuthSwiftHTTPRequestTests.swift
+//  OAuthSwift
+//
+//  Created by Benjamin Boxler on 26/10/2015.
+//  Copyright © 2015 Dongri Jin. All rights reserved.
+//
+
+import XCTest
+@testable import OAuthSwift
+
+class OAuthSwiftHTTPRequestTests: OAuthSwiftTests {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testFailure() {
+        let oAuthSwiftHTTPRequest = OAuthSwiftHTTPRequest(URL: NSURL(string: "http://127.0.0.1")!)
+        let failureExpectation = expectationWithDescription("Expexted `failure` to be called")
+        oAuthSwiftHTTPRequest.start()
+        oAuthSwiftHTTPRequest.failureHandler = { _ in
+            failureExpectation.fulfill()
+        }
+        oAuthSwiftHTTPRequest.successHandler = { _ in
+            XCTFail("The success handler should not be called. This can happen if you have a\nlocal server running on :80")
+        }
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testSuccess() {
+        let oAuthSwiftHTTPRequest = OAuthSwiftHTTPRequest(URL: NSURL(string: "http://127.0.0.1")!)
+        let successExpectation = expectationWithDescription("Expexted `failure` to be called")
+        oAuthSwiftHTTPRequest.start()
+        oAuthSwiftHTTPRequest.failureHandler = { _ in
+            XCTFail("The failure handler should not be called.")
+        }
+        oAuthSwiftHTTPRequest.successHandler = { _ in
+            successExpectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
+}

--- a/OAuthSwiftTests/OAuthSwiftHTTPRequestTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftHTTPRequestTests.swift
@@ -8,42 +8,52 @@
 
 import XCTest
 @testable import OAuthSwift
+import OHHTTPStubs
 
 class OAuthSwiftHTTPRequestTests: OAuthSwiftTests {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
+
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
     func testFailure() {
         let oAuthSwiftHTTPRequest = OAuthSwiftHTTPRequest(URL: NSURL(string: "http://127.0.0.1")!)
         let failureExpectation = expectationWithDescription("Expexted `failure` to be called")
-        oAuthSwiftHTTPRequest.start()
         oAuthSwiftHTTPRequest.failureHandler = { _ in
             failureExpectation.fulfill()
         }
         oAuthSwiftHTTPRequest.successHandler = { _ in
             XCTFail("The success handler should not be called. This can happen if you have a\nlocal server running on :80")
         }
+
+        oAuthSwiftHTTPRequest.start()
         waitForExpectationsWithTimeout(10, handler: nil)
     }
 
     func testSuccess() {
+        // Stub the request to return something
+        OHHTTPStubs.stubRequestsPassingTest({ request in
+                return request.URL!.host == "127.0.0.1"
+            }, withStubResponse: { _ in
+                return OHHTTPStubsResponse(
+                    data: NSString(string: "Success!").dataUsingEncoding(NSUTF8StringEncoding)!,
+                    statusCode: 200, headers: nil)
+
+        })
+
         let oAuthSwiftHTTPRequest = OAuthSwiftHTTPRequest(URL: NSURL(string: "http://127.0.0.1")!)
         let successExpectation = expectationWithDescription("Expexted `failure` to be called")
-        oAuthSwiftHTTPRequest.start()
         oAuthSwiftHTTPRequest.failureHandler = { _ in
             XCTFail("The failure handler should not be called.")
         }
-        oAuthSwiftHTTPRequest.successHandler = { _ in
-            successExpectation.fulfill()
+        oAuthSwiftHTTPRequest.successHandler = { (data, response) in
+            if String(data: data, encoding: NSUTF8StringEncoding) == "Success!" {
+                successExpectation.fulfill()
+            }
         }
+
+        oAuthSwiftHTTPRequest.start()
         waitForExpectationsWithTimeout(10, handler: nil)
     }
     

--- a/OAuthSwiftTests/OAuthSwiftTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftTests.swift
@@ -10,14 +10,6 @@ import XCTest
 
 class OAuthSwiftTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
+    // Common class. Put anything needed by all test classes in here
+
 }

--- a/OAuthSwiftTests/OAuthSwiftTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftTests.swift
@@ -1,0 +1,23 @@
+//
+//  OAuthSwiftTests.swift
+//  OAuthSwiftTests
+//
+//  Created by Benjamin Boxler on 26/10/2015.
+//  Copyright © 2015 Dongri Jin. All rights reserved.
+//
+
+import XCTest
+
+class OAuthSwiftTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+}

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,12 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '8.0'
+# Uncomment this line if you're using Swift
+use_frameworks!
+
+
+target 'OAuthSwiftTests' do
+
+  pod 'OHHTTPStubs', '~> 4.4.0'
+
+end
+


### PR DESCRIPTION
- Previously the NSHTTPURLResponse's status code passed to the completion handler of dataTaskWithRequest in start() in OAuthSwiftHTTPRequest was only checked after the response and data objects had been used. This PR fixes that.

- This adds a new class method setupRequestForOAuth(_:) to OAuthSwiftHTTPRequest that allows you to specify an existing url request.