### PR TITLE
Closes Issue #140 and #142.

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -103,8 +103,12 @@ public class OAuth1Swift: NSObject {
             data, response in
             let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String!
             let parameters = responseString.parametersFromQueryString()
-            self.client.credential.oauth_token = parameters["oauth_token"]!
-            self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!
+            if let oauthToken=parameters["oauth_token"] {
+                self.client.credential.oauth_token = oauthToken.stringByRemovingPercentEncoding!
+            }
+            if let oauthTokenSecret=parameters["oauth_token_secret"] {
+                self.client.credential.oauth_token_secret = oauthTokenSecret.stringByRemovingPercentEncoding!
+            }
             success(credential: self.client.credential, response: response)
         }, failure: failure)
     }
@@ -118,8 +122,12 @@ public class OAuth1Swift: NSObject {
             data, response in
             let responseString = NSString(data: data, encoding: NSUTF8StringEncoding) as String!
             let parameters = responseString.parametersFromQueryString()
-            self.client.credential.oauth_token = parameters["oauth_token"]!
-            self.client.credential.oauth_token_secret = parameters["oauth_token_secret"]!
+            if let oauthToken=parameters["oauth_token"] {
+                self.client.credential.oauth_token = oauthToken.stringByRemovingPercentEncoding!
+            }
+            if let oauthTokenSecret=parameters["oauth_token_secret"] {
+                self.client.credential.oauth_token_secret = oauthTokenSecret.stringByRemovingPercentEncoding!
+            }
             success(credential: self.client.credential, response: response)
         }, failure: failure)
     }


### PR DESCRIPTION
Added decoding the URL-encoded `oauth_token_secret` to the OAuth1 flow (in Step 1 and Step 3) so that it would complete. Previous escaped values were preventing proper OAuth signatures.