### PR TITLE
Fix #129 by adding OAUTH_APP_EXTENSIONS setting var

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -88,7 +88,9 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 delegateQueue: NSOperationQueue.mainQueue())
             let task: NSURLSessionDataTask = self.session.dataTaskWithRequest(self.request!) { data, response, error -> Void in
                 #if os(iOS)
-                    UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+                    #if !OAUTH_APP_EXTENSIONS
+                        UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+                    #endif
                 #endif
                 
                 self.response = response as? NSHTTPURLResponse
@@ -109,7 +111,9 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
             task.resume()
 
             #if os(iOS)
-                UIApplication.sharedApplication().networkActivityIndicatorVisible = true
+                #if !OAUTH_APP_EXTENSIONS
+                    UIApplication.sharedApplication().networkActivityIndicatorVisible = true
+                #endif
             #endif
         })
     }

--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -32,9 +32,25 @@ public class OAuthSwiftOpenURLExternally: OAuthSwiftURLHandlerType {
     
     @objc public func handle(url: NSURL) {
         #if os(iOS)
-            UIApplication.sharedApplication().openURL(url)
+            #if !OAUTH_APP_EXTENSIONS
+                UIApplication.sharedApplication().openURL(url)
+            #endif
         #elseif os(OSX)
             NSWorkspace.sharedWorkspace().openURL(url)
         #endif
+    }
+}
+
+// Open url using NSExtensionContext
+public class ExtensionContextURLHandler: OAuthSwiftURLHandlerType {
+    
+    private var extensionContext: NSExtensionContext
+    
+    public init(extensionContext: NSExtensionContext) {
+        self.extensionContext = extensionContext
+    }
+    
+    @objc public func handle(url: NSURL) {
+        extensionContext.openURL(url, completionHandler: nil)
     }
 }

--- a/OAuthSwift/OAuthWebViewController.swift
+++ b/OAuthSwift/OAuthWebViewController.swift
@@ -20,8 +20,10 @@ public class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerTy
 
     public func handle(url: NSURL){
         #if os(iOS)
-            UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(
-                self, animated: true, completion: nil)
+            #if !OAUTH_APP_EXTENSIONS
+                UIApplication.sharedApplication().keyWindow?.rootViewController?.presentViewController(
+                    self, animated: true, completion: nil)
+            #endif
         #elseif os(OSX)
             if let p = self.parentViewController { // default behaviour if this controller affected as child controller
                 p.presentViewControllerAsModalWindow(self)


### PR DESCRIPTION
to disable access to UIApplication.sharedApplication() into iOS app extension
Add also an url handler based on NSExtensionContext


The fix is inspired from AFNetworking fix https://github.com/AFNetworking/AFNetworking/issues/2119
The use need to use `post_install` into Podfile to inject setting into its extension target
https://guides.cocoapods.org/syntax/podfile.html#post_install
```
config.build_settings['OAUTH_APP_EXTENSIONS'] = '1'
```