### PR TITLE
Don't send emtpy Bearer tokens

### DIFF
--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -98,7 +98,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         case .OAuth1:
             return ["Authorization": self.authorizationHeaderForMethod(method, url: url, parameters: parameters, body: body)]
         case .OAuth2:
-            return ["Authorization": "Bearer \(self.oauth_token)"]
+            return self.oauth_token.isEmpty ? [:] : ["Authorization": "Bearer \(self.oauth_token)"]
         }
     }
 


### PR DESCRIPTION
As per [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1) the syntax for Bearer authentication is as follows:

```
  b64token    = 1*( ALPHA / DIGIT /
                    "-" / "." / "_" / "~" / "+" / "/" ) *"="
  credentials = "Bearer" 1*SP b64token
```

Note the `1*` which means "at least one repetition".

By definition, when one has an OAuth2 code and uses it to request an authorization token, the request cannot be made using Bearer authentication. The sent `Authorization` header is therefore invalid and can be rejected as a HTTP 400 (Bad Request) error.