### PR TITLE
SafariURLHandler: missing "public" access for externally configurable variables

### DIFF
--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -53,15 +53,15 @@ import SafariServices
         var observers = [String: AnyObject]()
 
         // configure
-        var animated: Bool = true
+        public var animated: Bool = true
         var factory: (URL: NSURL) -> SFSafariViewController = {URL in
             return SFSafariViewController(URL: URL)
         }
         
         // delegates
-        var delegate: SFSafariViewControllerDelegate?
-        var presentCompletion: (() -> Void)?
-        var dismissCompletion: (() -> Void)?
+        public var delegate: SFSafariViewControllerDelegate?
+        public var presentCompletion: (() -> Void)?
+        public var dismissCompletion: (() -> Void)?
         
         // init
         public init(viewController: UIViewController) {


### PR DESCRIPTION
Hi,

Thanks for the great work of making this happen - it helped us not to reinvent the wheel big time!

I came across the issue where the following variables on SafariURLHandler weren't accessible from outside of the framework (missing public annotiation):

        var animated: Bool = true
        var delegate: SFSafariViewControllerDelegate?
        var presentCompletion: (() -> Void)?
        var dismissCompletion: (() -> Void)?

Since I needed to customise the behaviour of this class I needed to set these - and at the same time I thought these were probably intended to be externally configurable originally. (otherwise these are not used inside the framework, so there's no point of their existence:)

Cheers,

Mark